### PR TITLE
Report `date_dt` as fractional days, not full days between

### DIFF
--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -810,21 +810,18 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
 
 
-                    from datetime import date, datetime
-#                    d0 = date(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
-#                    d1 = date(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
+                    from datetime import datetime, timedelta
+#                    d0 = datetime(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
+#                    d1 = datetime(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
                     d0 = datetime.strptime(master_dt,"%Y%m%dT%H:%M:%S.%f")
                     d1 = datetime.strptime(slave_dt,"%Y%m%dT%H:%M:%S.%f")
-                    date_dt_base = d1 - d0
-                    date_dt = np.float64(date_dt_base.days)
+                    date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
+                    date_dt = np.float64(date_dt_base)
                     if date_dt < 0:
                         raise Exception('Input image 1 must be older than input image 2')
-                    if date_dt_base.days < 0:
-                        date_ct = d1 + (d0 - d1)/2
-                        date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
-                    else:
-                        date_ct = d0 + (d1 - d0)/2
-                        date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+
+                    date_ct = d0 + (d1 - d0)/2
+                    date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
 
                     IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':'C','satellite_img1':master_split[0][1:3],'acquisition_img1':master_dt,'time_standard_img1':'UTC','absolute_orbit_number_img1':master_split[7],'mission_data_take_ID_img1':master_split[8],'product_unique_ID_img1':master_split[9][0:4],'flight_direction_img1':flight_direction_m,'mission_img2':slave_split[0][0],'sensor_img2':'C','satellite_img2':slave_split[0][1:3],'acquisition_img2':slave_dt,'time_standard_img2':'UTC','absolute_orbit_number_img2':slave_split[7],'mission_data_take_ID_img2':slave_split[8],'product_unique_ID_img2':slave_split[9][0:4],'flight_direction_img2':flight_direction_s,'date_dt':date_dt,'date_center':date_center,'latitude':cen_lat,'longitude':cen_lon,'roi_valid_percentage':PPP,'autoRIFT_software_version':version}
                     error_vector = np.array([[0.0356, 0.0501, 0.0266, 0.0622, 0.0357, 0.0501],
@@ -866,12 +863,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 #
 #                    master_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+master_MTL_path))[2][1:-2],':')
 #                    slave_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+slave_MTL_path))[2][1:-2],':')
-                    master_time = ['00','00','00']
-                    slave_time = ['00','00','00']
-
-                    from datetime import time as time1
-                    master_time = time1(int(master_time[0]),int(master_time[1]),int(float(master_time[2])))
-                    slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
 
                     import netcdf_output as no
                     pair_type = 'optical'
@@ -891,22 +882,19 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
-                    from datetime import date
-                    d0 = date(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
-                    d1 = date(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
-                    date_dt_base = d1 - d0
-                    date_dt = np.float64(date_dt_base.days)
+                    from datetime import datetime, timedelta
+                    d0 = datetime(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
+                    d1 = datetime(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
+                    date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
+                    date_dt = np.float64(date_dt_base)
                     if date_dt < 0:
                         raise Exception('Input image 1 must be older than input image 2')
-                    if date_dt_base.days < 0:
-                        date_ct = d1 + (d0 - d1)/2
-                        date_center = date_ct.strftime("%Y%m%d")
-                    else:
-                        date_ct = d0 + (d1 - d0)/2
-                        date_center = date_ct.strftime("%Y%m%d")
 
-                    master_dt = master_split[3][0:8] + master_time.strftime("T%H:%M:%S")
-                    slave_dt = slave_split[3][0:8] + slave_time.strftime("T%H:%M:%S")
+                    date_ct = d0 + (d1 - d0)/2
+                    date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+
+                    master_dt = d0.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+                    slave_dt = d1.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
 
                     IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':master_split[0][1],'satellite_img1':np.float64(master_split[0][2:4]),'correction_level_img1':master_split[1],'path_img1':np.float64(master_split[2][0:3]),'row_img1':np.float64(master_split[2][3:6]),'acquisition_date_img1':master_dt,'time_standard_img1':'UTC','processing_date_img1':master_split[4][0:8],'collection_number_img1':np.float64(master_split[5]),'collection_category_img1':master_split[6],'mission_img2':slave_split[0][0],'sensor_img2':slave_split[0][1],'satellite_img2':np.float64(slave_split[0][2:4]),'correction_level_img2':slave_split[1],'path_img2':np.float64(slave_split[2][0:3]),'row_img2':np.float64(slave_split[2][3:6]),'acquisition_date_img2':slave_dt,'time_standard_img2':'UTC','processing_date_img2':slave_split[4][0:8],'collection_number_img2':np.float64(slave_split[5]),'collection_category_img2':slave_split[6],'date_dt':date_dt,'date_center':date_center,'latitude':cen_lat,'longitude':cen_lon,'roi_valid_percentage':PPP,'autoRIFT_software_version':version}
 
@@ -943,13 +931,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     master_filename = master_split[0][-3:]+'_'+master_split[2]+'_'+master_split[4][:3]+'_'+os.path.basename(master_path)
                     slave_filename = slave_split[0][-3:]+'_'+slave_split[2]+'_'+slave_split[4][:3]+'_'+os.path.basename(slave_path)
 
-                    master_time = ['00','00','00']
-                    slave_time = ['00','00','00']
-
-                    from datetime import time as time1
-                    master_time = time1(int(master_time[0]),int(master_time[1]),int(float(master_time[2])))
-                    slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
-
                     import netcdf_output as no
                     pair_type = 'optical'
                     detection_method = 'feature'
@@ -966,22 +947,19 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
-                    from datetime import date
-                    d0 = date(np.int(master_split[2][0:4]),np.int(master_split[2][4:6]),np.int(master_split[2][6:8]))
-                    d1 = date(np.int(slave_split[2][0:4]),np.int(slave_split[2][4:6]),np.int(slave_split[2][6:8]))
-                    date_dt_base = d1 - d0
-                    date_dt = np.float64(date_dt_base.days)
+                    from datetime import datetime, timedelta
+                    d0 = datetime(np.int(master_split[2][0:4]),np.int(master_split[2][4:6]),np.int(master_split[2][6:8]))
+                    d1 = datetime(np.int(slave_split[2][0:4]),np.int(slave_split[2][4:6]),np.int(slave_split[2][6:8]))
+                    date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
+                    date_dt = np.float64(date_dt_base)
                     if date_dt < 0:
                         raise Exception('Input image 1 must be older than input image 2')
-                    if date_dt_base.days < 0:
-                        date_ct = d1 + (d0 - d1)/2
-                        date_center = date_ct.strftime("%Y%m%d")
-                    else:
-                        date_ct = d0 + (d1 - d0)/2
-                        date_center = date_ct.strftime("%Y%m%d")
 
-                    master_dt = master_split[2] + master_time.strftime("T%H:%M:%S")
-                    slave_dt = slave_split[2] + slave_time.strftime("T%H:%M:%S")
+                    date_ct = d0 + (d1 - d0) / 2
+                    date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+
+                    master_dt = d0.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+                    slave_dt = d1.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
 
                     IMG_INFO_DICT = {'mission_img1':master_split[0][-3],'satellite_img1':master_split[0][-2:],'correction_level_img1':master_split[4][:3],'acquisition_date_img1':master_dt,'time_standard_img1':'UTC','mission_img2':slave_split[0][-3],'satellite_img2':slave_split[0][-2:],'correction_level_img2':slave_split[4][:3],'acquisition_date_img2':slave_dt,'time_standard_img2':'UTC','date_dt':date_dt,'date_center':date_center,'latitude':cen_lat,'longitude':cen_lon,'roi_valid_percentage':PPP,'autoRIFT_software_version':version}
 

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -815,21 +815,18 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
 
 
-                    from datetime import date, datetime
-#                    d0 = date(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
-#                    d1 = date(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
+                    from datetime import datetime, timedelta
+#                    d0 = datetime(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
+#                    d1 = datetime(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
                     d0 = datetime.strptime(master_dt,"%Y%m%dT%H:%M:%S.%f")
                     d1 = datetime.strptime(slave_dt,"%Y%m%dT%H:%M:%S.%f")
-                    date_dt_base = d1 - d0
-                    date_dt = np.float64(date_dt_base.days)
+                    date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
+                    date_dt = np.float64(date_dt_base)
                     if date_dt < 0:
                         raise Exception('Input image 1 must be older than input image 2')
-                    if date_dt_base.days < 0:
-                        date_ct = d1 + (d0 - d1)/2
-                        date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
-                    else:
-                        date_ct = d0 + (d1 - d0)/2
-                        date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+
+                    date_ct = d0 + (d1 - d0)/2
+                    date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
 
                     IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':'C','satellite_img1':master_split[0][1:3],'acquisition_img1':master_dt,'time_standard_img1':'UTC','absolute_orbit_number_img1':master_split[7],'mission_data_take_ID_img1':master_split[8],'product_unique_ID_img1':master_split[9][0:4],'flight_direction_img1':flight_direction_m,'mission_img2':slave_split[0][0],'sensor_img2':'C','satellite_img2':slave_split[0][1:3],'acquisition_img2':slave_dt,'time_standard_img2':'UTC','absolute_orbit_number_img2':slave_split[7],'mission_data_take_ID_img2':slave_split[8],'product_unique_ID_img2':slave_split[9][0:4],'flight_direction_img2':flight_direction_s,'date_dt':date_dt,'date_center':date_center,'latitude':cen_lat,'longitude':cen_lon,'roi_valid_percentage':PPP,'autoRIFT_software_version':version}
                     error_vector = np.array([[0.0356, 0.0501, 0.0266, 0.0622, 0.0357, 0.0501],
@@ -871,12 +868,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 #
 #                    master_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+master_MTL_path))[2][1:-2],':')
 #                    slave_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+slave_MTL_path))[2][1:-2],':')
-                    master_time = ['00','00','00']
-                    slave_time = ['00','00','00']
-
-                    from datetime import time as time1
-                    master_time = time1(int(master_time[0]),int(master_time[1]),int(float(master_time[2])))
-                    slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
 
                     import netcdf_output as no
                     pair_type = 'optical'
@@ -895,22 +886,19 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
-                    from datetime import date
-                    d0 = date(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
-                    d1 = date(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
-                    date_dt_base = d1 - d0
-                    date_dt = np.float64(date_dt_base.days)
+                    from datetime import datetime, timedelta
+                    d0 = datetime(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
+                    d1 = datetime(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
+                    date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
+                    date_dt = np.float64(date_dt_base)
                     if date_dt < 0:
                         raise Exception('Input image 1 must be older than input image 2')
-                    if date_dt_base.days < 0:
-                        date_ct = d1 + (d0 - d1)/2
-                        date_center = date_ct.strftime("%Y%m%d")
-                    else:
-                        date_ct = d0 + (d1 - d0)/2
-                        date_center = date_ct.strftime("%Y%m%d")
 
-                    master_dt = master_split[3][0:8] + master_time.strftime("T%H:%M:%S")
-                    slave_dt = slave_split[3][0:8] + slave_time.strftime("T%H:%M:%S")
+                    date_ct = d0 + (d1 - d0)/2
+                    date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+
+                    master_dt = d0.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+                    slave_dt = d1.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
 
                     IMG_INFO_DICT = {'mission_img1':master_split[0][0],'sensor_img1':master_split[0][1],'satellite_img1':np.float64(master_split[0][2:4]),'correction_level_img1':master_split[1],'path_img1':np.float64(master_split[2][0:3]),'row_img1':np.float64(master_split[2][3:6]),'acquisition_date_img1':master_dt,'time_standard_img1':'UTC','processing_date_img1':master_split[4][0:8],'collection_number_img1':np.float64(master_split[5]),'collection_category_img1':master_split[6],'mission_img2':slave_split[0][0],'sensor_img2':slave_split[0][1],'satellite_img2':np.float64(slave_split[0][2:4]),'correction_level_img2':slave_split[1],'path_img2':np.float64(slave_split[2][0:3]),'row_img2':np.float64(slave_split[2][3:6]),'acquisition_date_img2':slave_dt,'time_standard_img2':'UTC','processing_date_img2':slave_split[4][0:8],'collection_number_img2':np.float64(slave_split[5]),'collection_category_img2':slave_split[6],'date_dt':date_dt,'date_center':date_center,'latitude':cen_lat,'longitude':cen_lon,'roi_valid_percentage':PPP,'autoRIFT_software_version':version}
 
@@ -947,13 +935,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     master_filename = master_split[0][-3:]+'_'+master_split[2]+'_'+master_split[4][:3]+'_'+os.path.basename(master_path)
                     slave_filename = slave_split[0][-3:]+'_'+slave_split[2]+'_'+slave_split[4][:3]+'_'+os.path.basename(slave_path)
 
-                    master_time = ['00','00','00']
-                    slave_time = ['00','00','00']
-
-                    from datetime import time as time1
-                    master_time = time1(int(master_time[0]),int(master_time[1]),int(float(master_time[2])))
-                    slave_time = time1(int(slave_time[0]),int(slave_time[1]),int(float(slave_time[2])))
-
                     import netcdf_output as no
                     pair_type = 'optical'
                     detection_method = 'feature'
@@ -970,22 +951,19 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
-                    from datetime import date
-                    d0 = date(np.int(master_split[2][0:4]),np.int(master_split[2][4:6]),np.int(master_split[2][6:8]))
-                    d1 = date(np.int(slave_split[2][0:4]),np.int(slave_split[2][4:6]),np.int(slave_split[2][6:8]))
-                    date_dt_base = d1 - d0
-                    date_dt = np.float64(date_dt_base.days)
+                    from datetime import datetime, timedelta
+                    d0 = datetime(np.int(master_split[2][0:4]),np.int(master_split[2][4:6]),np.int(master_split[2][6:8]))
+                    d1 = datetime(np.int(slave_split[2][0:4]),np.int(slave_split[2][4:6]),np.int(slave_split[2][6:8]))
+                    date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
+                    date_dt = np.float64(date_dt_base)
                     if date_dt < 0:
                         raise Exception('Input image 1 must be older than input image 2')
-                    if date_dt_base.days < 0:
-                        date_ct = d1 + (d0 - d1)/2
-                        date_center = date_ct.strftime("%Y%m%d")
-                    else:
-                        date_ct = d0 + (d1 - d0)/2
-                        date_center = date_ct.strftime("%Y%m%d")
 
-                    master_dt = master_split[2] + master_time.strftime("T%H:%M:%S")
-                    slave_dt = slave_split[2] + slave_time.strftime("T%H:%M:%S")
+                    date_ct = d0 + (d1 - d0) / 2
+                    date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+
+                    master_dt = d0.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
+                    slave_dt = d1.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
 
                     IMG_INFO_DICT = {'mission_img1':master_split[0][-3],'satellite_img1':master_split[0][-2:],'correction_level_img1':master_split[4][:3],'acquisition_date_img1':master_dt,'time_standard_img1':'UTC','mission_img2':slave_split[0][-3],'satellite_img2':slave_split[0][-2:],'correction_level_img2':slave_split[4][:3],'acquisition_date_img2':slave_dt,'time_standard_img2':'UTC','date_dt':date_dt,'date_center':date_center,'latitude':cen_lat,'longitude':cen_lon,'roi_valid_percentage':PPP,'autoRIFT_software_version':version}
 


### PR DESCRIPTION
Current implementation will round-down the `date_dt` attribute to the number of *full* days between acquisitions. 

For an extreme example, start with parsing the acquisition times, and getting the `datetime.timedelta`

```python
import numpy as np
from datetime import datetime

>>> d0 = datetime.strptime('2020-06-26T20:48:33Z', '%Y-%m-%dT%H:%M:%SZ')
... d1 = datetime.strptime('2020-07-01T20:48:30Z', '%Y-%m-%dT%H:%M:%SZ')
...
... dt = d1 - d0
>>> dt
datetime.timedelta(days=4, seconds=86397)
```
you can see datetime thinks of this as "four days plus some seconds". So that means, when the current `date_dt` is calculated, you get:
```python
>>> date_dt = np.float64(dt.days)
>>> date_dt
4.0
```
This switches to the actual fractional days, like:
```python
>>> dt.total_seconds() / timedelta(days=1).total_seconds()
4.999965277777778
```

