### PR TITLE
fix L8 name bugs

### DIFF
--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -875,7 +875,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
     #                out_nc_filename = 'Jakobshavn_opt.nc'
                     PPP = roi_valid_percentage * 100
                     if ncname is None:
-                        out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                        out_nc_filename = f"./{master_filename[0:-7]}_X_{slave_filename[0:-7]}" \
                                           f"_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     else:
                         out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -880,7 +880,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
     #                out_nc_filename = 'Jakobshavn_opt.nc'
                     PPP = roi_valid_percentage * 100
                     if ncname is None:
-                        out_nc_filename = f"./{master_filename[0:-8]}_X_{slave_filename[0:-8]}" \
+                        out_nc_filename = f"./{master_filename[0:-7]}_X_{slave_filename[0:-7]}" \
                                           f"_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     else:
                         out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"


### PR DESCRIPTION
revert to the [fix](https://github.com/nasa-jpl/autoRIFT/commit/7f26d18c1f5dfb9e9a5f70c5d3fc8ceafcf42355#diff-85f48f28cb350f823580b540bb462e7c033a1711e81b9ea6a3aaf7da56d88d23) that was already done by Joe, but was deleted by mistake.