### PR TITLE
add scale factor to Geogrid and autoRIFT-estimated velocity products

### DIFF
--- a/geo_autoRIFT/geogrid/Geogrid.py
+++ b/geo_autoRIFT/geogrid/Geogrid.py
@@ -310,6 +310,7 @@ class Geogrid(Component):
         geogrid.setWindowStableSurfaceMaskFilename_Py( self._geogrid, self.winssmname)
         geogrid.setRO2VXFilename_Py( self._geogrid, self.winro2vxname)
         geogrid.setRO2VYFilename_Py( self._geogrid, self.winro2vyname)
+        geogrid.setSFFilename_Py( self._geogrid, self.winsfname)
         geogrid.setLookSide_Py(self._geogrid, self.lookSide)
         geogrid.setNodataOut_Py(self._geogrid, self.nodata_out)
 
@@ -377,6 +378,7 @@ class Geogrid(Component):
         self.winssmname = None
         self.winro2vxname = None
         self.winro2vyname = None
+        self.winsfname = None
         
         ##dt-varying search range scale (srs) rountine parameters
         self.srs_dt_unity = 182

--- a/geo_autoRIFT/geogrid/GeogridOptical.py
+++ b/geo_autoRIFT/geogrid/GeogridOptical.py
@@ -245,6 +245,7 @@ class GeogridOptical():
         geogridOptical.setWindowStableSurfaceMaskFilename_Py( self._geogridOptical, self.winssmname)
         geogridOptical.setRO2VXFilename_Py( self._geogridOptical, self.winro2vxname)
         geogridOptical.setRO2VYFilename_Py( self._geogridOptical, self.winro2vyname)
+        geogridOptical.setSFFilename_Py( self._geogridOptical, self.winsfname)
         geogridOptical.setNodataOut_Py(self._geogridOptical, self.nodata_out)
         
     
@@ -380,6 +381,7 @@ class GeogridOptical():
         self.winssmname = None
         self.winro2vxname = None
         self.winro2vyname = None
+        self.winsfname = None
         
         ##dt-varying search range scale (srs) rountine parameters
         self.srs_dt_unity = 182

--- a/geo_autoRIFT/geogrid/bindings/geogridOpticalmodule.cpp
+++ b/geo_autoRIFT/geogrid/bindings/geogridOpticalmodule.cpp
@@ -405,6 +405,19 @@ PyObject* setRO2VYFilename(PyObject *self, PyObject *args)
     return Py_BuildValue("i", 0);
 }
 
+PyObject* setSFFilename(PyObject *self, PyObject *args)
+{
+    uint64_t ptr;
+    char* name;
+    if (!PyArg_ParseTuple(args, "Ks", &ptr, &name))
+    {
+        return NULL;
+    }
+    
+    ((geoGridOptical*)(ptr))->sfname = std::string(name);
+    return Py_BuildValue("i", 0);
+}
+
 
 PyObject* setNodataOut(PyObject *self, PyObject *args)
 {

--- a/geo_autoRIFT/geogrid/bindings/geogridmodule.cpp
+++ b/geo_autoRIFT/geogrid/bindings/geogridmodule.cpp
@@ -415,6 +415,19 @@ PyObject* setRO2VYFilename(PyObject *self, PyObject *args)
     return Py_BuildValue("i", 0);
 }
 
+PyObject* setSFFilename(PyObject *self, PyObject *args)
+{
+    uint64_t ptr;
+    char* name;
+    if (!PyArg_ParseTuple(args, "Ks", &ptr, &name))
+    {
+        return NULL;
+    }
+    
+    ((geoGrid*)(ptr))->sfname = std::string(name);
+    return Py_BuildValue("i", 0);
+}
+
 
 PyObject* setLookSide(PyObject *self, PyObject *args)
 {

--- a/geo_autoRIFT/geogrid/include/geogrid.h
+++ b/geo_autoRIFT/geogrid/include/geogrid.h
@@ -88,6 +88,7 @@ struct geoGrid
     std::string stablesurfacemaskname;
     std::string ro2vx_name;
     std::string ro2vy_name;
+    std::string sfname;
 
 
     //Functions

--- a/geo_autoRIFT/geogrid/include/geogridOptical.h
+++ b/geo_autoRIFT/geogrid/include/geogridOptical.h
@@ -79,6 +79,7 @@ struct geoGridOptical
     std::string stablesurfacemaskname;
     std::string ro2vx_name;
     std::string ro2vy_name;
+    std::string sfname;
 
     //Functions
     void computeBbox(double *);

--- a/geo_autoRIFT/geogrid/include/geogridOpticalmodule.h
+++ b/geo_autoRIFT/geogrid/include/geogridOpticalmodule.h
@@ -65,6 +65,7 @@ extern "C"
         PyObject * setWindowStableSurfaceMaskFilename(PyObject *, PyObject *);
         PyObject * setRO2VXFilename(PyObject *, PyObject *);
         PyObject * setRO2VYFilename(PyObject *, PyObject *);
+        PyObject * setSFFilename(PyObject *, PyObject *);
         PyObject * setEPSG(PyObject *, PyObject *);
         PyObject * setChipSizeX0(PyObject *, PyObject *);
         PyObject * setGridSpacingX(PyObject *, PyObject *);
@@ -118,6 +119,7 @@ static PyMethodDef geogrid_methods[] =
         {"setWindowStableSurfaceMaskFilename_Py", setWindowStableSurfaceMaskFilename, METH_VARARGS, " "},
         {"setRO2VXFilename_Py", setRO2VXFilename, METH_VARARGS, " "},
         {"setRO2VYFilename_Py", setRO2VYFilename, METH_VARARGS, " "},
+        {"setSFFilename_Py", setSFFilename, METH_VARARGS, " "},
         {NULL, NULL, 0, NULL}
 };
 #endif //geoGridOpticalmodule_h

--- a/geo_autoRIFT/geogrid/include/geogridmodule.h
+++ b/geo_autoRIFT/geogrid/include/geogridmodule.h
@@ -67,6 +67,7 @@ extern "C"
         PyObject * setWindowStableSurfaceMaskFilename(PyObject *, PyObject *);
         PyObject * setRO2VXFilename(PyObject *, PyObject *);
         PyObject * setRO2VYFilename(PyObject *, PyObject *);
+        PyObject * setSFFilename(PyObject *, PyObject *);
         PyObject * setEPSG(PyObject *, PyObject *);
         PyObject * setIncidenceAngle(PyObject *, PyObject *);
         PyObject * setChipSizeX0(PyObject *, PyObject *);
@@ -124,6 +125,7 @@ static PyMethodDef geogrid_methods[] =
         {"setWindowStableSurfaceMaskFilename_Py", setWindowStableSurfaceMaskFilename, METH_VARARGS, " "},
         {"setRO2VXFilename_Py", setRO2VXFilename, METH_VARARGS, " "},
         {"setRO2VYFilename_Py", setRO2VYFilename, METH_VARARGS, " "},
+        {"setSFFilename_Py", setSFFilename, METH_VARARGS, " "},
         {NULL, NULL, 0, NULL}
 };
 #endif //geoGridmodule_h

--- a/netcdf_output.py
+++ b/netcdf_output.py
@@ -152,7 +152,7 @@ def netCDF_read_intermediate(filename='./autoRIFT_intermediate.nc'):
 
 
 def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1, SX, SY,
-                     offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, offset2vr, offset2va, MM, VXref, VYref,
+                     offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, offset2vr, offset2va, scale_factor_1, scale_factor_2, MM, VXref, VYref,
                      DXref, DYref, rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type,
                      detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
                      dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector):
@@ -217,8 +217,8 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
         va_mean_shift1 = np.median(va_mean_shift1[np.logical_not(np.isnan(va_mean_shift1))])
 
         # create the (slope parallel & reference) flow-based range-projected result
-        alpha_sp = DX / (offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * (-SX) - offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * (-SY))
-        alpha_ref = DX / (offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VXref - offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VYref)
+        alpha_sp = (DX * scale_factor_1) / (offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * (-SX) - offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * (-SY))
+        alpha_ref = (DX * scale_factor_1) / (offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VXref - offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VYref)
         VXS = alpha_sp * (-SX)
         VYS = alpha_sp * (-SY)
         VXR = alpha_ref * VXref

--- a/testGeogridOptical.py
+++ b/testGeogridOptical.py
@@ -185,6 +185,7 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, c
     obj.winssmname = "window_stable_surface_mask.tif"
     obj.winro2vxname = "window_rdr_off2vel_x_vec.tif"
     obj.winro2vyname = "window_rdr_off2vel_y_vec.tif"
+    obj.winsfname = "window_scale_factor.tif"
     ##dt-varying search range scale (srs) rountine parameters
 #    obj.srs_dt_unity = 32
 #    obj.srs_max_scale = 10

--- a/testGeogrid_ISCE.py
+++ b/testGeogrid_ISCE.py
@@ -251,6 +251,7 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, c
     obj.winssmname = "window_stable_surface_mask.tif"
     obj.winro2vxname = "window_rdr_off2vel_x_vec.tif"
     obj.winro2vyname = "window_rdr_off2vel_y_vec.tif"
+    obj.winsfname = "window_scale_factor.tif"
     ##dt-varying search range scale (srs) rountine parameters
 #    obj.srs_dt_unity = 5
 #    obj.srs_max_scale = 10
@@ -335,6 +336,7 @@ def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, cs
     obj.winssmname = "window_stable_surface_mask.tif"
     obj.winro2vxname = "window_rdr_off2vel_x_vec.tif"
     obj.winro2vyname = "window_rdr_off2vel_y_vec.tif"
+    obj.winsfname = "window_scale_factor.tif"
     ##dt-varying search range scale (srs) rountine parameters
 #    obj.srs_dt_unity = 32
 #    obj.srs_max_scale = 10

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -1114,7 +1114,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     master_split = master_path.split('_')
                     slave_split = slave_path.split('_')
 
-                    import re
                     if re.findall("://",master_path).__len__() > 0:
                         master_filename_full = master_path.split('/')
                         for item in master_filename_full:

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -26,7 +26,7 @@
 #
 # Author: Yang Lei
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-import re
+import re as ree
 from osgeo import gdal
 from datetime import datetime, timedelta
 
@@ -64,6 +64,8 @@ def cmdLineParse():
             help='Input pixel offsets to vx conversion coefficients file name')
     parser.add_argument('-vy', '--input_vy', dest='offset2vy', type=str, required=False,
             help='Input pixel offsets to vy conversion coefficients file name')
+    parser.add_argument('-sf', '--input_scale_factor', dest='scale_factor', type=str, required=False,
+            help='Input map projection scale factor file name')
     parser.add_argument('-ssm', '--input_ssm', dest='stable_surface_mask', type=str, required=False,
             help='Input stable surface mask file name')
     parser.add_argument('-fo', '--flag_optical', dest='optical_flag', type=bool, required=False, default=0,
@@ -394,13 +396,13 @@ def main():
     generateAutoriftProduct(indir_m=inps.indir_m, indir_s=inps.indir_s, grid_location=inps.grid_location,
                             init_offset=inps.init_offset, search_range=inps.search_range,
                             chip_size_min=inps.chip_size_min,chip_size_max=inps.chip_size_max,
-                            offset2vx=inps.offset2vx, offset2vy=inps.offset2vy,
+                            offset2vx=inps.offset2vx, offset2vy=inps.offset2vy, scale_factor=inps.scale_factor,
                             stable_surface_mask=inps.stable_surface_mask, optical_flag=inps.optical_flag,
                             nc_sensor=inps.nc_sensor, mpflag=inps.mpflag, ncname=inps.ncname)
 
 
 def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search_range, chip_size_min, chip_size_max,
-                            offset2vx, offset2vy, stable_surface_mask, optical_flag, nc_sensor, mpflag, ncname,
+                            offset2vx, offset2vy, scale_factor, stable_surface_mask, optical_flag, nc_sensor, mpflag, ncname,
                             geogrid_run_info=None):
 
     import numpy as np
@@ -508,7 +510,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
-            if len(re.findall("L[EO]07_", name)) > 0:
+            if len(ree.findall("L[EO]07_", name)) > 0:
                 acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
                 if acquisition >= datetime(2003, 5, 31):
                     preprocessing_methods[ii] = 'wallis_fill'
@@ -604,6 +606,16 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
 
         if offset2vx is not None:
+        
+            ds = gdal.Open(scale_factor)
+            band = ds.GetRasterBand(1)
+            scale_factor_1 = band.ReadAsArray()
+            band = ds.GetRasterBand(2)
+            scale_factor_2 = band.ReadAsArray()
+            band=None
+            ds=None
+            scale_factor_1[scale_factor_1 == nodata] = np.nan
+            scale_factor_2[scale_factor_2 == nodata] = np.nan
 
             ds = gdal.Open(offset2vx)
             band = ds.GetRasterBand(1)
@@ -639,8 +651,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
             if offset2va is not None:
                 offset2va[offset2va == nodata] = np.nan
 
-            VX = offset2vx_1 * DX + offset2vx_2 * DY
-            VY = offset2vy_1 * DX + offset2vy_2 * DY
+            VX = offset2vx_1 * (DX * scale_factor_1) + offset2vx_2 * (DY * scale_factor_2)
+            VY = offset2vy_1 * (DX * scale_factor_1) + offset2vy_2 * (DY * scale_factor_2)
             VX = VX.astype(np.float32)
             VY = VY.astype(np.float32)
 
@@ -723,6 +735,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                 DXref = offset2vy_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VXref - offset2vx_2 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VYref
                 DYref = offset2vx_1 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VYref - offset2vy_1 / (offset2vx_1 * offset2vy_2 - offset2vx_2 * offset2vy_1) * VXref
+                DXref = DXref / scale_factor_1
+                DYref = DYref / scale_factor_2
 
 #                stable_count = np.sum(SSM & np.logical_not(np.isnan(DX)) & (DX-DXref > -5) & (DX-DXref < 5) & (DY-DYref > -5) & (DY-DYref < 5))
                 stable_count = np.sum(SSM & np.logical_not(np.isnan(DX)))
@@ -777,8 +791,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     DY = DY - dy_mean_shift
 
 
-                VX = offset2vx_1 * DX + offset2vx_2 * DY
-                VY = offset2vy_1 * DX + offset2vy_2 * DY
+                VX = offset2vx_1 * (DX * scale_factor_1) + offset2vx_2 * (DY * scale_factor_2)
+                VY = offset2vy_1 * (DX * scale_factor_1) + offset2vy_2 * (DY * scale_factor_2)
                 VX = VX.astype(np.float32)
                 VY = VY.astype(np.float32)
 
@@ -873,7 +887,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                     netcdf_file = no.netCDF_packaging(
                         VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1, SX, SY,
-                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, offset2vr, offset2va, MM, VXref, VYref,
+                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, offset2vr, offset2va, scale_factor_1, scale_factor_2, MM, VXref, VYref,
                         DXref, DYref, rangePixelSize, azimuthPixelSize, dt, epsg, srs, tran, out_nc_filename, pair_type,
                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
                         dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
@@ -973,7 +987,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                     netcdf_file = no.netCDF_packaging(
                         VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1, SX, SY,
-                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, None, None, MM, VXref, VYref,
+                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, None, None, scale_factor_1, scale_factor_2, MM, VXref, VYref,
                         None, None, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
                         dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
@@ -1073,7 +1087,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                     netcdf_file = no.netCDF_packaging(
                         VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1, SX, SY,
-                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, None, None, MM, VXref, VYref,
+                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, None, None, scale_factor_1, scale_factor_2, MM, VXref, VYref,
                         None, None, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
                         dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
@@ -1170,7 +1184,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
                     netcdf_file = no.netCDF_packaging(
                         VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1, SX, SY,
-                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, None, None, MM, VXref, VYref,
+                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, None, None, scale_factor_1, scale_factor_2, MM, VXref, VYref,
                         None, None, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
                         detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
                         dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -26,7 +26,7 @@
 #
 # Author: Yang Lei
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-import re as ree
+import re
 from osgeo import gdal
 from datetime import datetime, timedelta
 
@@ -510,7 +510,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
-            if len(ree.findall("L[EO]07_", name)) > 0:
+            if len(re.findall("L[EO]07_", name)) > 0:
                 acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
                 if acquisition >= datetime(2003, 5, 31):
                     preprocessing_methods[ii] = 'wallis_fill'
@@ -1113,7 +1113,6 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     master_split = master_path.split('_')
                     slave_split = slave_path.split('_')
 
-                    import re
                     if re.findall("://",master_path).__len__() > 0:
                         master_filename_full = master_path.split('/')
                         for item in master_filename_full:


### PR DESCRIPTION
1. added a new 2-band raster output "window_scale_factor.tif" in Geogrid and fixed a few misuses of pixel size in image vs. map coordinates.
2. incorporated the new Geogrid output "window_scale_factor.tif" in autoRIFT for producing the velocity products
3. transferred scale factor (2-band raster) to netcdf packaging in case you want to package them as well in the final netcdf file 

**NOTE**: Please note I have tested the new Geogrid output "window_scale_factor.tif" as well as the autoRIFT velocity product "velocity.tif" for one S1 and one L8 image pair. The results look reasonable, with the value of scale factor being very close to 1 (e.g. 1.0001 or 0.9999). The velocity only has changes at the 1st or 2nd decimal compared to the original case. You might want to do more tests before merging the PR to double check.