### PR TITLE
Use a different filter width for Sentinel-1

### DIFF
--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -34,7 +34,8 @@ import sys
 import numpy as np
 from scipy import ndimage
 from scipy.ndimage import distance_transform_edt
-
+from scipy.spatial import distance as dist
+import numpy.fft as fft
 
 
 def _remove_local_mean(image, kernel):
@@ -44,9 +45,9 @@ def _remove_local_mean(image, kernel):
 
 def _preprocess_filt_std(image, kernel):
     conv_sum = cv2.filter2D(image, -1, kernel, borderType=cv2.BORDER_REFLECT)
-    conv_squared_sum = cv2.filter2D(image ** 2, -1, kernel, borderType=cv2.BORDER_REFLECT)
+    conv_squared_sum = cv2.filter2D(image**2, -1, kernel, borderType=cv2.BORDER_REFLECT)
 
-    variance = conv_squared_sum - (conv_sum ** 2)
+    variance = conv_squared_sum - (conv_sum**2)
     std = np.sqrt(variance)
     return std
 
@@ -62,7 +63,7 @@ def _wallis_filter(image, filter_width):
 
 
 def _wallis_filter_fill(image, filter_width, std_cutoff):
-    image = np.ma.masked_values(image, 0.)
+    image = np.ma.masked_values(image, 0.0)
     buff = np.sqrt(2 * ((filter_width - 1) / 2) ** 2) + 0.01
 
     # find edges of image, this makes missing scan lines valid and will
@@ -99,47 +100,88 @@ def _wallis_filter_fill(image, filter_width, std_cutoff):
     return image, zero_mask
 
 
-def _find_largest_region(arr):
-    binary_arr = np.zeros(arr.shape)
-    binary_arr[arr != 0] = 1
-    label_arr, nb_labels = ndimage.label(binary_arr)
-    sizes = ndimage.sum(binary_arr, label_arr, range(nb_labels + 1))
-    max_label = sizes.argmax()
+def _find_largest_region(binary_arr):
+    n_labels, label_arr, stats, centroids = cv2.connectedComponentsWithStats(binary_arr)
+    area = stats[:, cv2.CC_STAT_AREA]
+    max_label = area[1:].argmax() + 1
     label_arr[label_arr != max_label] = 0
     return label_arr
 
 
-def _fft_filter(Ix, valid_domain, power_threshold=500):
-    import numpy.fft as fft
-    m, n = valid_domain.shape
-    center_m = int(np.floor(m / 2))
-    center_n = int(np.floor(n / 2))
+def _calculate_slope(point1, point2):
+    slope = np.rad2deg(np.arctan((point1[1] - point2[1]) / (point1[0] - point2[0])))
+    return slope
 
-    single_region = _find_largest_region(Ix)
+
+def _order_points(pts):
+    x_sorted = pts[np.argsort(pts[:, 0]), :]
+    left_most = x_sorted[:2, :]
+    right_most = x_sorted[2:, :]
+    left_most = left_most[np.argsort(left_most[:, 1]), :]
+    (tl, bl) = left_most
+    D = dist.cdist(tl[np.newaxis], right_most, "euclidean")[0]
+    (br, tr) = right_most[np.argsort(D)[::-1], :]
+    return np.array([tl, tr, br, bl], dtype="float32")
+
+
+def get_slopes(corners):
+    tl, tr, br, bl = _order_points(corners)
+    slope1 = _calculate_slope(br, bl)
+    slope2 = _calculate_slope(tr, tl)
+    slope3 = _calculate_slope(tr, br)
+    slope4 = _calculate_slope(tl, bl)
+    along_track_angle = -1 * np.nanmax([slope3, slope4])
+    cross_track_angle = -1 * np.nanmax([slope1, slope2])
+    return along_track_angle, cross_track_angle
+
+
+def _fft_filter(Ix, valid_domain, power_threshold):
+    y, x = valid_domain.shape
+    center_y = y / 2
+    center_y_int = np.floor(y / 2).astype(int)
+    center_x = x / 2
+    center_x_int = np.floor(x / 2).astype(int)
+
+    regions = (valid_domain != 0).astype("uint8") * 255
+    single_region = _find_largest_region(regions)
     single_region = np.uint8(single_region * 255)
     contours, hierarchy = cv2.findContours(single_region, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
     if hierarchy.shape[1] > 1:
-        raise ValueError(f'{hierarchy.shape[1]} external objects founds, only expecting 1.')
+        raise ValueError(f"{hierarchy.shape[1]} external objects found, only expecting 1.")
     contour = contours[0]
-    moment = cv2.moments(contour)
 
-    centroid_m = int(np.floor(moment['m01'] / moment['m00']))
-    centroid_n = int(np.floor(moment['m10'] / moment['m00']))
-    rectangle = cv2.minAreaRect(contour)
-    angle = rectangle[2]
+    hull = cv2.convexHull(contour, returnPoints=True)
+    hull_image = np.zeros(valid_domain.shape, dtype=np.uint8)
+    hull_image = cv2.drawContours(hull_image, [hull], -1, 255)
+    corners = cv2.goodFeaturesToTrack(hull_image, 4, 0.33, 1000)[:, 0, :]
+    if corners[0] < 4:
+        raise ValueError(f"Only {corners[0]} corners found, expecting 4.")
 
-    filter_base = np.full((m, n), False)
-    filter_base[center_m - 70:center_m + 70, :] = 1
-    filter_base[:, center_n - 100:center_n + 100] = 0
+    along_track, cross_track = get_slopes(corners)
+    print(f"Along track angle is {along_track:.2f} degrees")
 
-    filter_a = ndimage.rotate(filter_base, -angle, reshape=False)
-    filter_b = ndimage.rotate(filter_base, 90 - angle, reshape=False)
+    filter_base = np.zeros((y, x))
+    filter_base[center_y_int - 70 : center_y_int + 70, :] = 1
+    filter_base[:, center_x_int - 100 : center_x_int + 100] = 0
 
-    ctr_shift = [centroid_m - center_m, centroid_n - center_n]
+    rotation_a = cv2.getRotationMatrix2D(center=(center_x, center_y), angle=cross_track, scale=1)
+    rotation_b = cv2.getRotationMatrix2D(center=(center_x, center_y), angle=along_track, scale=1)
+    filter_a = cv2.warpAffine(src=filter_base, M=rotation_a, dsize=(x, y))
+    filter_b = cv2.warpAffine(src=filter_base, M=rotation_b, dsize=(x, y))
 
-    translate_matrix = np.array([(1, 0, ctr_shift[0]), (0, 1, ctr_shift[1]), (0, 0, 1)])
-    filter_a = ndimage.affine_transform(filter_a, matrix=translate_matrix)
-    filter_b = ndimage.affine_transform(filter_b, matrix=translate_matrix)
+    # Alex's code appears note to use this shift
+    # moment = cv2.moments(contour)
+    # centroid_y = moment["m01"] / moment["m00"]
+    # centroid_x = moment["m10"] / moment["m00"]
+    # y_shift = centroid_y - center_y
+    # x_shift = centroid_x - center_x
+    # print(f"shift = ({x_shift:.1f},{y_shift:.1f})")
+
+    # translation = np.array([[1, 0, x_shift],
+    #                         [0, 1, y_shift]],
+    #                        dtype=np.float32)
+    # filter_a = cv2.warpAffine(src=filter_a, M=translation, dsize=(x, y))
+    # filter_b = cv2.warpAffine(src=filter_b, M=translation, dsize=(x, y))
 
     image = Ix.copy()
     image[image > 3] = 3
@@ -164,8 +206,10 @@ def _fft_filter(Ix, valid_domain, power_threshold=500):
         filtered_image = np.real(fft.ifft2(fft.ifftshift(fft_image * (1 - (final_filter)))))
         filtered_image[~valid_domain] = 0
     else:
-        print(f'Power along flight direction ({max(sB, sA)}) does not exceed banding threshold ({power_threshold}). '
-              f'No banding filter applied.')
+        print(
+            f"Power along flight direction ({max(sB, sA)}) does not exceed banding threshold ({power_threshold}). "
+            f"No banding filter applied."
+        )
         return image
 
     return filtered_image
@@ -199,9 +243,9 @@ class autoRIFT:
         self.I2 = _wallis_filter(self.I2, self.WallisFilterWidth)
 
     def preprocess_filt_hps(self):
-        '''
+        """
         Do the pre processing using (orig - low-pass filter) = high-pass filter filter (3.9/5.3 min).
-        '''
+        """
         import cv2
         import numpy as np
 
@@ -218,20 +262,24 @@ class autoRIFT:
         self.I2 = cv2.filter2D(self.I2, -1, kernel, borderType=cv2.BORDER_CONSTANT)
 
     def preprocess_filt_fft(self):
-        '''
+        """
         Preprocess images to remove banding perpendicular to the along flight direction by masking in frequency space
-        '''
-        self.I1 = _fft_filter(self.I1, (self.I1 != 0).astype(int), power_threshold=500)
-        self.I2 = _fft_filter(self.I2, (self.I2 != 0).astype(int), power_threshold=500)
+        """
+        self.WallisFilterWidth = 5
+        self.zeroMask = self.I1 == 0
+        self.I1 = _wallis_filter(self.I1, self.WallisFilterWidth)
+        self.I1 = _fft_filter(self.I1, self.zeroMask.astype(int), power_threshold=500)
+        print("fft done")
+        # self.I2 = _fft_filter(self.I2, (self.I2 != 0).astype(int), power_threshold=500)
 
     def preprocess_db(self):
-        '''
+        """
         Do the pre processing using db scale (4 min).
-        '''
+        """
         import cv2
         import numpy as np
 
-        self.zeroMask = (self.I1 == 0)
+        self.zeroMask = self.I1 == 0
 
         #        pdb.set_trace()
 
@@ -240,9 +288,9 @@ class autoRIFT:
         self.I2 = 20.0 * np.log10(self.I2)
 
     def preprocess_filt_sob(self):
-        '''
+        """
         Do the pre processing using sobel filter (4.5/5.8 min).
-        '''
+        """
         import cv2
         import numpy as np
 
@@ -261,13 +309,13 @@ class autoRIFT:
         self.I2 = cv2.filter2D(self.I2, -1, kernel, borderType=cv2.BORDER_CONSTANT)
 
     def preprocess_filt_lap(self):
-        '''
+        """
         Do the pre processing using Laplacian filter (2.5 min / 4 min).
-        '''
+        """
         import cv2
         import numpy as np
 
-        self.zeroMask = (self.I1 == 0)
+        self.zeroMask = self.I1 == 0
 
         self.I1 = 20.0 * np.log10(self.I1)
         self.I1 = cv2.Laplacian(self.I1, -1, ksize=self.WallisFilterWidth, borderType=cv2.BORDER_CONSTANT)
@@ -288,7 +336,7 @@ class autoRIFT:
                 temp = self.I1
             S1 = np.std(temp) * np.sqrt(temp.size / (temp.size - 1.0))
             M1 = np.mean(temp)
-            self.I1 = (self.I1 - (M1 - 3 * S1)) / (6 * S1) * (2 ** 8 - 0)
+            self.I1 = (self.I1 - (M1 - 3 * S1)) / (6 * S1) * (2**8 - 0)
 
             #            self.I1[np.logical_not(np.isfinite(self.I1))] = 0
             self.I1 = np.round(np.clip(self.I1, 0, 255)).astype(np.uint8)
@@ -301,7 +349,7 @@ class autoRIFT:
                 temp = self.I2
             S2 = np.std(temp) * np.sqrt(temp.size / (temp.size - 1.0))
             M2 = np.mean(temp)
-            self.I2 = (self.I2 - (M2 - 3 * S2)) / (6 * S2) * (2 ** 8 - 0)
+            self.I2 = (self.I2 - (M2 - 3 * S2)) / (6 * S2) * (2**8 - 0)
 
             #            self.I2[np.logical_not(np.isfinite(self.I2))] = 0
             self.I2 = np.round(np.clip(self.I2, 0, 255)).astype(np.uint8)
@@ -326,12 +374,12 @@ class autoRIFT:
                 self.zeroMask = None
 
         else:
-            sys.exit('invalid data type for the image pair which must be unsigned integer 8 or 32-bit float')
+            sys.exit("invalid data type for the image pair which must be unsigned integer 8 or 32-bit float")
 
     def autorift(self):
-        '''
+        """
         Do the actual processing.
-        '''
+        """
         import numpy as np
         import cv2
         from scipy import ndimage
@@ -340,21 +388,24 @@ class autoRIFT:
         ChipSizeUniX = np.delete(ChipSizeUniX, np.where(ChipSizeUniX == 0)[0])
 
         if np.any(np.mod(ChipSizeUniX, self.ChipSize0X) != 0):
-            sys.exit('chip sizes must be even integers of ChipSize0')
+            sys.exit("chip sizes must be even integers of ChipSize0")
 
         ChipRangeX = self.ChipSize0X * np.array([1, 2, 4, 8, 16, 32, 64], np.float32)
         #        ChipRangeX = ChipRangeX[ChipRangeX < (2**8 - 1)]
         if np.max(ChipSizeUniX) > np.max(ChipRangeX):
-            sys.exit('max each chip size is out of range')
+            sys.exit("max each chip size is out of range")
 
         ChipSizeUniX = ChipRangeX[(ChipRangeX >= np.min(ChipSizeUniX)) & (ChipRangeX <= np.max(ChipSizeUniX))]
 
         maxScale = np.max(ChipSizeUniX) / self.ChipSize0X
 
         if (np.mod(self.xGrid.shape[0], maxScale) != 0) | (np.mod(self.xGrid.shape[1], maxScale) != 0):
-            message = 'xgrid and ygrid have an incorect size ' + str(
-                self.xGrid.shape) + ' for nested search, they must have dimensions that an interger multiple of ' + str(
-                maxScale)
+            message = (
+                "xgrid and ygrid have an incorect size "
+                + str(self.xGrid.shape)
+                + " for nested search, they must have dimensions that an interger multiple of "
+                + str(maxScale)
+            )
             sys.exit(message)
 
         self.xGrid = self.xGrid.astype(np.float32)
@@ -397,7 +448,8 @@ class autoRIFT:
         if self.ChipSize0X > self.GridSpacingX:
             if np.mod(self.ChipSize0X, self.GridSpacingX) != 0:
                 sys.exit(
-                    'when GridSpacing < smallest allowable chip size (ChipSize0), ChipSize0 must be integer multiples of GridSpacing')
+                    "when GridSpacing < smallest allowable chip size (ChipSize0), ChipSize0 must be integer multiples of GridSpacing"
+                )
             else:
                 ChipSize0_GridSpacing_oversample_ratio = int(self.ChipSize0X / self.GridSpacingX)
         else:
@@ -405,7 +457,7 @@ class autoRIFT:
 
         DispFiltC = DISP_FILT()
         overlap_c = np.max((1 - self.sparseSearchSampleRate / ChipSize0_GridSpacing_oversample_ratio, 0))
-        DispFiltC.FracValid = self.FracValid * (1 - overlap_c) + overlap_c ** 2
+        DispFiltC.FracValid = self.FracValid * (1 - overlap_c) + overlap_c**2
         DispFiltC.FracSearch = self.FracSearch
         DispFiltC.FiltWidth = (self.FiltWidth - 1) * ChipSize0_GridSpacing_oversample_ratio + 1
         DispFiltC.Iter = self.Iter - 1
@@ -414,7 +466,7 @@ class autoRIFT:
 
         DispFiltF = DISP_FILT()
         overlap_f = 1 - 1 / ChipSize0_GridSpacing_oversample_ratio
-        DispFiltF.FracValid = self.FracValid * (1 - overlap_f) + overlap_f ** 2
+        DispFiltF.FracValid = self.FracValid * (1 - overlap_f) + overlap_f**2
         DispFiltF.FracSearch = self.FracSearch
         DispFiltF.FiltWidth = (self.FiltWidth - 1) * ChipSize0_GridSpacing_oversample_ratio + 1
         DispFiltF.Iter = self.Iter
@@ -439,17 +491,16 @@ class autoRIFT:
 
                 M0 = (ChipSizeX == 0) & (self.ChipSizeMinX <= ChipSizeUniX[i]) & (self.ChipSizeMaxX >= ChipSizeUniX[i])
                 M0 = colfilt(M0.copy(), (int(1 / Scale * 6), int(1 / Scale * 6)), 0, self.colfiltChunkSize)
-                M0 = cv2.resize(np.logical_not(M0).astype(np.uint8), dstShape[::-1],
-                                interpolation=cv2.INTER_NEAREST).astype(np.bool)
+                M0 = cv2.resize(
+                    np.logical_not(M0).astype(np.uint8), dstShape[::-1], interpolation=cv2.INTER_NEAREST
+                ).astype(np.bool)
 
-                SearchLimitX0 = colfilt(self.SearchLimitX.copy(), (int(1 / Scale), int(1 / Scale)), 0,
-                                        self.colfiltChunkSize) + colfilt(self.Dx0.copy(),
-                                                                         (int(1 / Scale), int(1 / Scale)), 4,
-                                                                         self.colfiltChunkSize)
-                SearchLimitY0 = colfilt(self.SearchLimitY.copy(), (int(1 / Scale), int(1 / Scale)), 0,
-                                        self.colfiltChunkSize) + colfilt(self.Dy0.copy(),
-                                                                         (int(1 / Scale), int(1 / Scale)), 4,
-                                                                         self.colfiltChunkSize)
+                SearchLimitX0 = colfilt(
+                    self.SearchLimitX.copy(), (int(1 / Scale), int(1 / Scale)), 0, self.colfiltChunkSize
+                ) + colfilt(self.Dx0.copy(), (int(1 / Scale), int(1 / Scale)), 4, self.colfiltChunkSize)
+                SearchLimitY0 = colfilt(
+                    self.SearchLimitY.copy(), (int(1 / Scale), int(1 / Scale)), 0, self.colfiltChunkSize
+                ) + colfilt(self.Dy0.copy(), (int(1 / Scale), int(1 / Scale)), 4, self.colfiltChunkSize)
                 Dx00 = colfilt(self.Dx0.copy(), (int(1 / Scale), int(1 / Scale)), 2, self.colfiltChunkSize)
                 Dy00 = colfilt(self.Dy0.copy(), (int(1 / Scale), int(1 / Scale)), 2, self.colfiltChunkSize)
 
@@ -481,15 +532,22 @@ class autoRIFT:
             SearchLimitY0[(np.logical_not(idxZero)) & (SearchLimitY0 < self.minSearch)] = self.minSearch
 
             if ((xGrid0.shape[0] - 2) / (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio) < 5) | (
-                    (xGrid0.shape[1] - 2) / (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio) < 5):
+                (xGrid0.shape[1] - 2) / (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio) < 5
+            ):
                 Flag = 2
                 return Flag
 
             # Setup for coarse search: sparse sampling / resize
-            rIdxC = slice((self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio) - 1, xGrid0.shape[0],
-                          (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio))
-            cIdxC = slice((self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio) - 1, xGrid0.shape[1],
-                          (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio))
+            rIdxC = slice(
+                (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio) - 1,
+                xGrid0.shape[0],
+                (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio),
+            )
+            cIdxC = slice(
+                (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio) - 1,
+                xGrid0.shape[1],
+                (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio),
+            )
             xGrid0C = xGrid0[rIdxC, cIdxC]
             yGrid0C = yGrid0[rIdxC, cIdxC]
 
@@ -498,7 +556,7 @@ class autoRIFT:
             if np.remainder((self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio), 2) == 0:
                 filtWidth = (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio) + 1
             else:
-                filtWidth = (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio)
+                filtWidth = self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio
 
             SearchLimitX0C = colfilt(SearchLimitX0.copy(), (int(filtWidth), int(filtWidth)), 0, self.colfiltChunkSize)
             SearchLimitY0C = colfilt(SearchLimitY0.copy(), (int(filtWidth), int(filtWidth)), 0, self.colfiltChunkSize)
@@ -521,34 +579,61 @@ class autoRIFT:
             #            pdb.set_trace()
 
             if self.I1.dtype == np.uint8:
-                DxC, DyC = arImgDisp_u(self.I2.copy(), self.I1.copy(), xGrid0C.copy(), yGrid0C.copy(), ChipSizeXC,
-                                       ChipSizeYC, SearchLimitX0C.copy(), SearchLimitY0C.copy(), Dx0C.copy(),
-                                       Dy0C.copy(), SubPixFlag, overSampleRatio, self.MultiThread)
+                DxC, DyC = arImgDisp_u(
+                    self.I2.copy(),
+                    self.I1.copy(),
+                    xGrid0C.copy(),
+                    yGrid0C.copy(),
+                    ChipSizeXC,
+                    ChipSizeYC,
+                    SearchLimitX0C.copy(),
+                    SearchLimitY0C.copy(),
+                    Dx0C.copy(),
+                    Dy0C.copy(),
+                    SubPixFlag,
+                    overSampleRatio,
+                    self.MultiThread,
+                )
             elif self.I1.dtype == np.float32:
-                DxC, DyC = arImgDisp_s(self.I2.copy(), self.I1.copy(), xGrid0C.copy(), yGrid0C.copy(), ChipSizeXC,
-                                       ChipSizeYC, SearchLimitX0C.copy(), SearchLimitY0C.copy(), Dx0C.copy(),
-                                       Dy0C.copy(), SubPixFlag, overSampleRatio, self.MultiThread)
+                DxC, DyC = arImgDisp_s(
+                    self.I2.copy(),
+                    self.I1.copy(),
+                    xGrid0C.copy(),
+                    yGrid0C.copy(),
+                    ChipSizeXC,
+                    ChipSizeYC,
+                    SearchLimitX0C.copy(),
+                    SearchLimitY0C.copy(),
+                    Dx0C.copy(),
+                    Dy0C.copy(),
+                    SubPixFlag,
+                    overSampleRatio,
+                    self.MultiThread,
+                )
             else:
-                sys.exit('invalid data type for the image pair which must be unsigned integer 8 or 32-bit float')
+                sys.exit("invalid data type for the image pair which must be unsigned integer 8 or 32-bit float")
 
             #            pdb.set_trace()
 
             # M0C is the mask for reliable estimates after coarse search, MC is the mask after disparity filtering, MC2 is the mask after area closing for fine search
             M0C = np.logical_not(np.isnan(DxC))
 
-            MC = DispFiltC.filtDisp(DxC.copy(), DyC.copy(), SearchLimitX0C.copy(), SearchLimitY0C.copy(), M0C.copy(),
-                                    overSampleRatio)
+            MC = DispFiltC.filtDisp(
+                DxC.copy(), DyC.copy(), SearchLimitX0C.copy(), SearchLimitY0C.copy(), M0C.copy(), overSampleRatio
+            )
 
             MC[np.logical_not(M0C)] = False
 
-            ROIC = (SearchLimitX0C > 0)
+            ROIC = SearchLimitX0C > 0
             CoarseCorValidFac = np.sum(MC[ROIC]) / np.sum(M0C[ROIC])
-            if (CoarseCorValidFac < self.CoarseCorCutoff):
+            if CoarseCorValidFac < self.CoarseCorCutoff:
                 continue
 
             MC2 = ndimage.distance_transform_edt(np.logical_not(MC)) < self.BuffDistanceC
-            dstShape = (int(MC2.shape[0] * (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio)),
-                        int(MC2.shape[1] * (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio)))
+            dstShape = (
+                int(MC2.shape[0] * (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio)),
+                int(MC2.shape[1] * (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio)),
+            )
 
             MC2 = cv2.resize(MC2.astype(np.uint8), dstShape[::-1], interpolation=cv2.INTER_NEAREST).astype(np.bool)
             #            pdb.set_trace()
@@ -569,20 +654,50 @@ class autoRIFT:
             ChipSizeYF = np.float32(np.round(ChipSizeXF * self.ScaleChipSizeY / 2) * 2)
             #            pdb.set_trace()
             if self.I1.dtype == np.uint8:
-                DxF, DyF = arImgDisp_u(self.I2.copy(), self.I1.copy(), xGrid0.copy(), yGrid0.copy(), ChipSizeXF,
-                                       ChipSizeYF, SearchLimitX0.copy(), SearchLimitY0.copy(), Dx00.copy(), Dy00.copy(),
-                                       SubPixFlag, overSampleRatio, self.MultiThread)
+                DxF, DyF = arImgDisp_u(
+                    self.I2.copy(),
+                    self.I1.copy(),
+                    xGrid0.copy(),
+                    yGrid0.copy(),
+                    ChipSizeXF,
+                    ChipSizeYF,
+                    SearchLimitX0.copy(),
+                    SearchLimitY0.copy(),
+                    Dx00.copy(),
+                    Dy00.copy(),
+                    SubPixFlag,
+                    overSampleRatio,
+                    self.MultiThread,
+                )
             elif self.I1.dtype == np.float32:
-                DxF, DyF = arImgDisp_s(self.I2.copy(), self.I1.copy(), xGrid0.copy(), yGrid0.copy(), ChipSizeXF,
-                                       ChipSizeYF, SearchLimitX0.copy(), SearchLimitY0.copy(), Dx00.copy(), Dy00.copy(),
-                                       SubPixFlag, overSampleRatio, self.MultiThread)
+                DxF, DyF = arImgDisp_s(
+                    self.I2.copy(),
+                    self.I1.copy(),
+                    xGrid0.copy(),
+                    yGrid0.copy(),
+                    ChipSizeXF,
+                    ChipSizeYF,
+                    SearchLimitX0.copy(),
+                    SearchLimitY0.copy(),
+                    Dx00.copy(),
+                    Dy00.copy(),
+                    SubPixFlag,
+                    overSampleRatio,
+                    self.MultiThread,
+                )
             else:
-                sys.exit('invalid data type for the image pair which must be unsigned integer 8 or 32-bit float')
+                sys.exit("invalid data type for the image pair which must be unsigned integer 8 or 32-bit float")
 
             #            pdb.set_trace()
 
-            M0 = DispFiltF.filtDisp(DxF.copy(), DyF.copy(), SearchLimitX0.copy(), SearchLimitY0.copy(),
-                                    np.logical_not(np.isnan(DxF)), overSampleRatio)
+            M0 = DispFiltF.filtDisp(
+                DxF.copy(),
+                DyF.copy(),
+                SearchLimitX0.copy(),
+                SearchLimitY0.copy(),
+                np.logical_not(np.isnan(DxF)),
+                overSampleRatio,
+            )
             #            pdb.set_trace()
             DxF[np.logical_not(M0)] = np.nan
             DyF[np.logical_not(M0)] = np.nan
@@ -597,11 +712,13 @@ class autoRIFT:
 
             for j in range(3):
                 foo = MF | M0  # initial valid estimates
-                foo1 = (cv2.filter2D(foo.astype(np.float32), -1, np.ones((3, 3)),
-                                     borderType=cv2.BORDER_CONSTANT) >= 6) | foo  # 1st area closing followed by the 2nd (part of the next line calling OpenCV)
+                foo1 = (
+                    cv2.filter2D(foo.astype(np.float32), -1, np.ones((3, 3)), borderType=cv2.BORDER_CONSTANT) >= 6
+                ) | foo  # 1st area closing followed by the 2nd (part of the next line calling OpenCV)
                 #                pdb.set_trace()
-                fillIdx = np.logical_not(bwareaopen(np.logical_not(foo1).astype(np.uint8), 5)) & np.logical_not(
-                    foo) & MM
+                fillIdx = (
+                    np.logical_not(bwareaopen(np.logical_not(foo1).astype(np.uint8), 5)) & np.logical_not(foo) & MM
+                )
                 MF[fillIdx] = True
                 DxF[fillIdx] = DxFM[fillIdx]
                 DyF[fillIdx] = DyFM[fillIdx]
@@ -664,9 +781,9 @@ class autoRIFT:
         self.ChipSizeY = ChipSizeY
 
     def runAutorift(self):
-        '''
+        """
         quick processing routine which calls autorift main function (user can define their own way by mimicing the workflow here).
-        '''
+        """
         import numpy as np
 
         # truncate the grid to fit the nested grid
@@ -759,16 +876,16 @@ var_dict = {}
 
 
 def initializer(I1, I2, xGrid, yGrid, SearchLimitX, SearchLimitY, ChipSizeX, ChipSizeY, Dx0, Dy0):
-    var_dict['I1'] = I1
-    var_dict['I2'] = I2
-    var_dict['xGrid'] = xGrid
-    var_dict['yGrid'] = yGrid
-    var_dict['SearchLimitX'] = SearchLimitX
-    var_dict['SearchLimitY'] = SearchLimitY
-    var_dict['ChipSizeX'] = ChipSizeX
-    var_dict['ChipSizeY'] = ChipSizeY
-    var_dict['Dx0'] = Dx0
-    var_dict['Dy0'] = Dy0
+    var_dict["I1"] = I1
+    var_dict["I2"] = I2
+    var_dict["xGrid"] = xGrid
+    var_dict["yGrid"] = yGrid
+    var_dict["SearchLimitX"] = SearchLimitX
+    var_dict["SearchLimitY"] = SearchLimitY
+    var_dict["ChipSizeX"] = ChipSizeX
+    var_dict["ChipSizeY"] = ChipSizeY
+    var_dict["Dx0"] = Dx0
+    var_dict["Dy0"] = Dy0
 
 
 def unpacking_loop_u(tup):
@@ -783,16 +900,16 @@ def unpacking_loop_u(tup):
 
     k, chunkInds, SubPixFlag, oversample, in_shape, I_shape = tup
 
-    I1 = np.frombuffer(var_dict['I1'], dtype=np.uint8).reshape(I_shape)
-    I2 = np.frombuffer(var_dict['I2'], dtype=np.uint8).reshape(I_shape)
-    xGrid = np.frombuffer(var_dict['xGrid'], dtype=np.float32).reshape(in_shape)
-    yGrid = np.frombuffer(var_dict['yGrid'], dtype=np.float32).reshape(in_shape)
-    SearchLimitX = np.frombuffer(var_dict['SearchLimitX'], dtype=np.float32).reshape(in_shape)
-    SearchLimitY = np.frombuffer(var_dict['SearchLimitY'], dtype=np.float32).reshape(in_shape)
-    ChipSizeX = np.frombuffer(var_dict['ChipSizeX'], dtype=np.float32).reshape(in_shape)
-    ChipSizeY = np.frombuffer(var_dict['ChipSizeY'], dtype=np.float32).reshape(in_shape)
-    Dx0 = np.frombuffer(var_dict['Dx0'], dtype=np.float32).reshape(in_shape)
-    Dy0 = np.frombuffer(var_dict['Dy0'], dtype=np.float32).reshape(in_shape)
+    I1 = np.frombuffer(var_dict["I1"], dtype=np.uint8).reshape(I_shape)
+    I2 = np.frombuffer(var_dict["I2"], dtype=np.uint8).reshape(I_shape)
+    xGrid = np.frombuffer(var_dict["xGrid"], dtype=np.float32).reshape(in_shape)
+    yGrid = np.frombuffer(var_dict["yGrid"], dtype=np.float32).reshape(in_shape)
+    SearchLimitX = np.frombuffer(var_dict["SearchLimitX"], dtype=np.float32).reshape(in_shape)
+    SearchLimitY = np.frombuffer(var_dict["SearchLimitY"], dtype=np.float32).reshape(in_shape)
+    ChipSizeX = np.frombuffer(var_dict["ChipSizeX"], dtype=np.float32).reshape(in_shape)
+    ChipSizeY = np.frombuffer(var_dict["ChipSizeY"], dtype=np.float32).reshape(in_shape)
+    Dx0 = np.frombuffer(var_dict["Dx0"], dtype=np.float32).reshape(in_shape)
+    Dy0 = np.frombuffer(var_dict["Dy0"], dtype=np.float32).reshape(in_shape)
 
     Dx = np.empty(chunkInds.shape, dtype=np.float32)
     Dx.fill(np.nan)
@@ -818,10 +935,12 @@ def unpacking_loop_u(tup):
         ChipRangeY = slice(int(-cly - Dy0[ii, jj] + yGrid[ii, jj]), int(cly - Dy0[ii, jj] + yGrid[ii, jj]))
         ChipI = I2[ChipRangeY, ChipRangeX]
 
-        SearchRangeX = slice(int(-clx - SearchLimitX[ii, jj] + xGrid[ii, jj]),
-                             int(clx + SearchLimitX[ii, jj] - 1 + xGrid[ii, jj]))
-        SearchRangeY = slice(int(-cly - SearchLimitY[ii, jj] + yGrid[ii, jj]),
-                             int(cly + SearchLimitY[ii, jj] - 1 + yGrid[ii, jj]))
+        SearchRangeX = slice(
+            int(-clx - SearchLimitX[ii, jj] + xGrid[ii, jj]), int(clx + SearchLimitX[ii, jj] - 1 + xGrid[ii, jj])
+        )
+        SearchRangeY = slice(
+            int(-cly - SearchLimitY[ii, jj] + yGrid[ii, jj]), int(cly + SearchLimitY[ii, jj] - 1 + yGrid[ii, jj])
+        )
         RefI = I1[SearchRangeY, SearchRangeX]
 
         minChipI = np.min(ChipI)
@@ -839,15 +958,32 @@ def unpacking_loop_u(tup):
         if SubPixFlag:
             # call C++
             Dx[ind1], Dy[ind1] = np.float32(
-                autoriftcore.arSubPixDisp_u_Py(core._autoriftcore, ChipI.shape[1], ChipI.shape[0], ChipI.ravel(),
-                                               RefI.shape[1], RefI.shape[0], RefI.ravel(), oversample))
+                autoriftcore.arSubPixDisp_u_Py(
+                    core._autoriftcore,
+                    ChipI.shape[1],
+                    ChipI.shape[0],
+                    ChipI.ravel(),
+                    RefI.shape[1],
+                    RefI.shape[0],
+                    RefI.ravel(),
+                    oversample,
+                )
+            )
         #                   # call Python
         #                   Dx1[ii], Dy1[ii] = arSubPixDisp(ChipI,RefI)
         else:
             # call C++
             Dx[ind1], Dy[ind1] = np.float32(
-                autoriftcore.arPixDisp_u_Py(core._autoriftcore, ChipI.shape[1], ChipI.shape[0], ChipI.ravel(),
-                                            RefI.shape[1], RefI.shape[0], RefI.ravel()))
+                autoriftcore.arPixDisp_u_Py(
+                    core._autoriftcore,
+                    ChipI.shape[1],
+                    ChipI.shape[0],
+                    ChipI.ravel(),
+                    RefI.shape[1],
+                    RefI.shape[0],
+                    RefI.ravel(),
+                )
+            )
     #                   # call Python
     #                   Dx1[ii], Dy1[ii] = arPixDisp(ChipI,RefI)
     return Dx, Dy
@@ -865,16 +1001,16 @@ def unpacking_loop_s(tup):
 
     k, chunkInds, SubPixFlag, oversample, in_shape, I_shape = tup
 
-    I1 = np.frombuffer(var_dict['I1'], dtype=np.float32).reshape(I_shape)
-    I2 = np.frombuffer(var_dict['I2'], dtype=np.float32).reshape(I_shape)
-    xGrid = np.frombuffer(var_dict['xGrid'], dtype=np.float32).reshape(in_shape)
-    yGrid = np.frombuffer(var_dict['yGrid'], dtype=np.float32).reshape(in_shape)
-    SearchLimitX = np.frombuffer(var_dict['SearchLimitX'], dtype=np.float32).reshape(in_shape)
-    SearchLimitY = np.frombuffer(var_dict['SearchLimitY'], dtype=np.float32).reshape(in_shape)
-    ChipSizeX = np.frombuffer(var_dict['ChipSizeX'], dtype=np.float32).reshape(in_shape)
-    ChipSizeY = np.frombuffer(var_dict['ChipSizeY'], dtype=np.float32).reshape(in_shape)
-    Dx0 = np.frombuffer(var_dict['Dx0'], dtype=np.float32).reshape(in_shape)
-    Dy0 = np.frombuffer(var_dict['Dy0'], dtype=np.float32).reshape(in_shape)
+    I1 = np.frombuffer(var_dict["I1"], dtype=np.float32).reshape(I_shape)
+    I2 = np.frombuffer(var_dict["I2"], dtype=np.float32).reshape(I_shape)
+    xGrid = np.frombuffer(var_dict["xGrid"], dtype=np.float32).reshape(in_shape)
+    yGrid = np.frombuffer(var_dict["yGrid"], dtype=np.float32).reshape(in_shape)
+    SearchLimitX = np.frombuffer(var_dict["SearchLimitX"], dtype=np.float32).reshape(in_shape)
+    SearchLimitY = np.frombuffer(var_dict["SearchLimitY"], dtype=np.float32).reshape(in_shape)
+    ChipSizeX = np.frombuffer(var_dict["ChipSizeX"], dtype=np.float32).reshape(in_shape)
+    ChipSizeY = np.frombuffer(var_dict["ChipSizeY"], dtype=np.float32).reshape(in_shape)
+    Dx0 = np.frombuffer(var_dict["Dx0"], dtype=np.float32).reshape(in_shape)
+    Dy0 = np.frombuffer(var_dict["Dy0"], dtype=np.float32).reshape(in_shape)
 
     Dx = np.empty(chunkInds.shape, dtype=np.float32)
     Dx.fill(np.nan)
@@ -900,10 +1036,12 @@ def unpacking_loop_s(tup):
         ChipRangeY = slice(int(-cly - Dy0[ii, jj] + yGrid[ii, jj]), int(cly - Dy0[ii, jj] + yGrid[ii, jj]))
         ChipI = I2[ChipRangeY, ChipRangeX]
 
-        SearchRangeX = slice(int(-clx - SearchLimitX[ii, jj] + xGrid[ii, jj]),
-                             int(clx + SearchLimitX[ii, jj] - 1 + xGrid[ii, jj]))
-        SearchRangeY = slice(int(-cly - SearchLimitY[ii, jj] + yGrid[ii, jj]),
-                             int(cly + SearchLimitY[ii, jj] - 1 + yGrid[ii, jj]))
+        SearchRangeX = slice(
+            int(-clx - SearchLimitX[ii, jj] + xGrid[ii, jj]), int(clx + SearchLimitX[ii, jj] - 1 + xGrid[ii, jj])
+        )
+        SearchRangeY = slice(
+            int(-cly - SearchLimitY[ii, jj] + yGrid[ii, jj]), int(cly + SearchLimitY[ii, jj] - 1 + yGrid[ii, jj])
+        )
         RefI = I1[SearchRangeY, SearchRangeX]
 
         minChipI = np.min(ChipI)
@@ -921,22 +1059,52 @@ def unpacking_loop_s(tup):
         if SubPixFlag:
             # call C++
             Dx[ind1], Dy[ind1] = np.float32(
-                autoriftcore.arSubPixDisp_s_Py(core._autoriftcore, ChipI.shape[1], ChipI.shape[0], ChipI.ravel(),
-                                               RefI.shape[1], RefI.shape[0], RefI.ravel(), oversample))
+                autoriftcore.arSubPixDisp_s_Py(
+                    core._autoriftcore,
+                    ChipI.shape[1],
+                    ChipI.shape[0],
+                    ChipI.ravel(),
+                    RefI.shape[1],
+                    RefI.shape[0],
+                    RefI.ravel(),
+                    oversample,
+                )
+            )
         #                   # call Python
         #                   Dx1[ii], Dy1[ii] = arSubPixDisp(ChipI,RefI)
         else:
             # call C++
             Dx[ind1], Dy[ind1] = np.float32(
-                autoriftcore.arPixDisp_s_Py(core._autoriftcore, ChipI.shape[1], ChipI.shape[0], ChipI.ravel(),
-                                            RefI.shape[1], RefI.shape[0], RefI.ravel()))
+                autoriftcore.arPixDisp_s_Py(
+                    core._autoriftcore,
+                    ChipI.shape[1],
+                    ChipI.shape[0],
+                    ChipI.ravel(),
+                    RefI.shape[1],
+                    RefI.shape[0],
+                    RefI.ravel(),
+                )
+            )
     #                   # call Python
     #                   Dx1[ii], Dy1[ii] = arPixDisp(ChipI,RefI)
     return Dx, Dy
 
 
-def arImgDisp_u(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, SearchLimitY, Dx0, Dy0, SubPixFlag,
-                oversample, MultiThread):
+def arImgDisp_u(
+    I1,
+    I2,
+    xGrid,
+    yGrid,
+    ChipSizeX,
+    ChipSizeY,
+    SearchLimitX,
+    SearchLimitY,
+    Dx0,
+    Dy0,
+    SubPixFlag,
+    oversample,
+    MultiThread,
+):
     import numpy as np
     from . import autoriftcore
     import multiprocessing as mp
@@ -956,24 +1124,24 @@ def arImgDisp_u(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
 
     if np.size(SearchLimitX) == 1:
         if np.logical_not(isinstance(SearchLimitX, np.float32) & isinstance(SearchLimitY, np.float32)):
-            sys.exit('SearchLimit must be float')
+            sys.exit("SearchLimit must be float")
     else:
         if np.logical_not((SearchLimitX.dtype == np.float32) & (SearchLimitY.dtype == np.float32)):
-            sys.exit('SearchLimit must be float')
+            sys.exit("SearchLimit must be float")
 
     if np.size(Dx0) == 1:
         if np.logical_not(isinstance(Dx0, np.float32) & isinstance(Dy0, np.float32)):
-            sys.exit('Search offsets must be float')
+            sys.exit("Search offsets must be float")
     else:
         if np.logical_not((Dx0.dtype == np.float32) & (Dy0.dtype == np.float32)):
-            sys.exit('Search offsets must be float')
+            sys.exit("Search offsets must be float")
 
     if np.size(ChipSizeX) == 1:
         if np.logical_not(isinstance(ChipSizeX, np.float32) & isinstance(ChipSizeY, np.float32)):
-            sys.exit('ChipSize must be float')
+            sys.exit("ChipSize must be float")
     else:
         if np.logical_not((ChipSizeX.dtype == np.float32) & (ChipSizeY.dtype == np.float32)):
-            sys.exit('ChipSize must be float')
+            sys.exit("ChipSize must be float")
 
     if np.any(np.mod(ChipSizeX, 2) != 0) | np.any(np.mod(ChipSizeY, 2) != 0):
         #        if np.any(np.mod(xGrid-0.5,1) == 0) & np.any(np.mod(yGrid-0.5,1) == 0):
@@ -981,16 +1149,16 @@ def arImgDisp_u(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
         #        else:
         #            xGrid = np.ceil(xGrid)
         #            yGrid = np.ceil(yGrid)
-        sys.exit('it is better to have ChipSize = even number')
+        sys.exit("it is better to have ChipSize = even number")
 
     if np.any(np.mod(SearchLimitX, 1) != 0) | np.any(np.mod(SearchLimitY, 1) != 0):
-        sys.exit('SearchLimit must be an integar value')
+        sys.exit("SearchLimit must be an integar value")
 
     if np.any(SearchLimitX < 0) | np.any(SearchLimitY < 0):
-        sys.exit('SearchLimit cannot be negative')
+        sys.exit("SearchLimit cannot be negative")
 
     if np.any(np.mod(ChipSizeX, 4) != 0) | np.any(np.mod(ChipSizeY, 4) != 0):
-        sys.exit('ChipSize should be evenly divisible by 4')
+        sys.exit("ChipSize should be evenly divisible by 4")
 
     if np.size(Dx0) == 1:
         Dx0 = np.ones(xGrid.shape, dtype=np.float32) * Dx0
@@ -1018,12 +1186,12 @@ def arImgDisp_u(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
     SLy_max = np.max(SearchLimitY + np.abs(Dy0))
     Py = np.int(np.max(ChipSizeY) / 2 + SLy_max + 2)
 
-    I1 = np.lib.pad(I1, ((Py, Py), (Px, Px)), 'constant')
-    I2 = np.lib.pad(I2, ((Py, Py), (Px, Px)), 'constant')
+    I1 = np.lib.pad(I1, ((Py, Py), (Px, Px)), "constant")
+    I2 = np.lib.pad(I2, ((Py, Py), (Px, Px)), "constant")
 
     # adjust center location by the padarray size and 0.5 is added because we need to extract the chip centered at X+1 with -chipsize/2:chipsize/2-1, which equivalently centers at X+0.5 (X is the original grid point location). So for even chipsize, always returns offset estimates at (X+0.5).
-    xGrid += (Px + 0.5)
-    yGrid += (Py + 0.5)
+    xGrid += Px + 0.5
+    yGrid += Py + 0.5
 
     Dx = np.empty(xGrid.shape, dtype=np.float32)
     Dx.fill(np.nan)
@@ -1046,10 +1214,14 @@ def arImgDisp_u(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
                 ChipRangeY = slice(int(-cly - Dy0[ii, jj] + yGrid[ii, jj]), int(cly - Dy0[ii, jj] + yGrid[ii, jj]))
                 ChipI = I2[ChipRangeY, ChipRangeX]
 
-                SearchRangeX = slice(int(-clx - SearchLimitX[ii, jj] + xGrid[ii, jj]),
-                                     int(clx + SearchLimitX[ii, jj] - 1 + xGrid[ii, jj]))
-                SearchRangeY = slice(int(-cly - SearchLimitY[ii, jj] + yGrid[ii, jj]),
-                                     int(cly + SearchLimitY[ii, jj] - 1 + yGrid[ii, jj]))
+                SearchRangeX = slice(
+                    int(-clx - SearchLimitX[ii, jj] + xGrid[ii, jj]),
+                    int(clx + SearchLimitX[ii, jj] - 1 + xGrid[ii, jj]),
+                )
+                SearchRangeY = slice(
+                    int(-cly - SearchLimitY[ii, jj] + yGrid[ii, jj]),
+                    int(cly + SearchLimitY[ii, jj] - 1 + yGrid[ii, jj]),
+                )
                 RefI = I1[SearchRangeY, SearchRangeX]
 
                 minChipI = np.min(ChipI)
@@ -1067,16 +1239,32 @@ def arImgDisp_u(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
                 if SubPixFlag:
                     # call C++
                     Dx1[ii], Dy1[ii] = np.float32(
-                        autoriftcore.arSubPixDisp_u_Py(core._autoriftcore, ChipI.shape[1], ChipI.shape[0],
-                                                       ChipI.ravel(), RefI.shape[1], RefI.shape[0], RefI.ravel(),
-                                                       oversample))
+                        autoriftcore.arSubPixDisp_u_Py(
+                            core._autoriftcore,
+                            ChipI.shape[1],
+                            ChipI.shape[0],
+                            ChipI.ravel(),
+                            RefI.shape[1],
+                            RefI.shape[0],
+                            RefI.ravel(),
+                            oversample,
+                        )
+                    )
                 #                   # call Python
                 #                   Dx1[ii], Dy1[ii] = arSubPixDisp(ChipI,RefI)
                 else:
                     # call C++
                     Dx1[ii], Dy1[ii] = np.float32(
-                        autoriftcore.arPixDisp_u_Py(core._autoriftcore, ChipI.shape[1], ChipI.shape[0], ChipI.ravel(),
-                                                    RefI.shape[1], RefI.shape[0], RefI.ravel()))
+                        autoriftcore.arPixDisp_u_Py(
+                            core._autoriftcore,
+                            ChipI.shape[1],
+                            ChipI.shape[0],
+                            ChipI.ravel(),
+                            RefI.shape[1],
+                            RefI.shape[0],
+                            RefI.ravel(),
+                        )
+                    )
     #                   # call Python
     #                   Dx1[ii], Dy1[ii] = arPixDisp(ChipI,RefI)
     else:
@@ -1087,49 +1275,49 @@ def arImgDisp_u(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
 
         #        import pdb
         #        pdb.set_trace()
-        XI1 = mp.RawArray('b', np.asscalar(np.prod(I_shape)))
+        XI1 = mp.RawArray("b", np.asscalar(np.prod(I_shape)))
         XI1_np = np.frombuffer(XI1, dtype=np.uint8).reshape(I_shape)
         np.copyto(XI1_np, I1)
         del I1
 
-        XI2 = mp.RawArray('b', np.asscalar(np.prod(I_shape)))
+        XI2 = mp.RawArray("b", np.asscalar(np.prod(I_shape)))
         XI2_np = np.frombuffer(XI2, dtype=np.uint8).reshape(I_shape)
         np.copyto(XI2_np, I2)
         del I2
 
-        XxGrid = mp.RawArray('f', shape_prod)
+        XxGrid = mp.RawArray("f", shape_prod)
         XxGrid_np = np.frombuffer(XxGrid, dtype=np.float32).reshape(in_shape)
         np.copyto(XxGrid_np, xGrid)
         del xGrid
 
-        XyGrid = mp.RawArray('f', shape_prod)
+        XyGrid = mp.RawArray("f", shape_prod)
         XyGrid_np = np.frombuffer(XyGrid, dtype=np.float32).reshape(in_shape)
         np.copyto(XyGrid_np, yGrid)
         del yGrid
 
-        XSearchLimitX = mp.RawArray('f', shape_prod)
+        XSearchLimitX = mp.RawArray("f", shape_prod)
         XSearchLimitX_np = np.frombuffer(XSearchLimitX, dtype=np.float32).reshape(in_shape)
         np.copyto(XSearchLimitX_np, SearchLimitX)
 
-        XSearchLimitY = mp.RawArray('f', shape_prod)
+        XSearchLimitY = mp.RawArray("f", shape_prod)
         XSearchLimitY_np = np.frombuffer(XSearchLimitY, dtype=np.float32).reshape(in_shape)
         np.copyto(XSearchLimitY_np, SearchLimitY)
 
-        XChipSizeX = mp.RawArray('f', shape_prod)
+        XChipSizeX = mp.RawArray("f", shape_prod)
         XChipSizeX_np = np.frombuffer(XChipSizeX, dtype=np.float32).reshape(in_shape)
         np.copyto(XChipSizeX_np, ChipSizeX)
         del ChipSizeX
 
-        XChipSizeY = mp.RawArray('f', shape_prod)
+        XChipSizeY = mp.RawArray("f", shape_prod)
         XChipSizeY_np = np.frombuffer(XChipSizeY, dtype=np.float32).reshape(in_shape)
         np.copyto(XChipSizeY_np, ChipSizeY)
         del ChipSizeY
 
-        XDx0 = mp.RawArray('f', shape_prod)
+        XDx0 = mp.RawArray("f", shape_prod)
         XDx0_np = np.frombuffer(XDx0, dtype=np.float32).reshape(in_shape)
         np.copyto(XDx0_np, Dx0)
 
-        XDy0 = mp.RawArray('f', shape_prod)
+        XDy0 = mp.RawArray("f", shape_prod)
         XDy0_np = np.frombuffer(XDy0, dtype=np.float32).reshape(in_shape)
         np.copyto(XDy0_np, Dy0)
         #        import pdb
@@ -1151,11 +1339,12 @@ def arImgDisp_u(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
             CHUNKS.append(chunkInds)
         #            print(CHUNKS)
 
-        chunk_inputs = [(kk, CHUNKS[kk], SubPixFlag, oversample, in_shape, I_shape)
-                        for kk in range(Nchunks)]
+        chunk_inputs = [(kk, CHUNKS[kk], SubPixFlag, oversample, in_shape, I_shape) for kk in range(Nchunks)]
 
-        with mp.Pool(initializer=initializer, initargs=(
-                XI1, XI2, XxGrid, XyGrid, XSearchLimitX, XSearchLimitY, XChipSizeX, XChipSizeY, XDx0, XDy0)) as pool:
+        with mp.Pool(
+            initializer=initializer,
+            initargs=(XI1, XI2, XxGrid, XyGrid, XSearchLimitX, XSearchLimitY, XChipSizeX, XChipSizeY, XDx0, XDy0),
+        ) as pool:
             Dx, Dy = zip(*pool.map(unpacking_loop_u, chunk_inputs))
 
         Dx = np.concatenate(Dx)
@@ -1167,8 +1356,8 @@ def arImgDisp_u(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
     # add back 1) I1 (RefI) relative to I2 (ChipI) initial offset Dx0 and Dy0, and
     #          2) RefI relative to ChipI has a left/top boundary offset of -SearchLimitX and -SearchLimitY
     idx = np.logical_not(np.isnan(Dx))
-    Dx[idx] += (Dx0[idx] - SearchLimitX[idx])
-    Dy[idx] += (Dy0[idx] - SearchLimitY[idx])
+    Dx[idx] += Dx0[idx] - SearchLimitX[idx]
+    Dy[idx] += Dy0[idx] - SearchLimitY[idx]
 
     # convert from matrix X-Y to cartesian X-Y: X no change, Y from down being positive to up being positive
     Dy = -Dy
@@ -1179,8 +1368,21 @@ def arImgDisp_u(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
     return Dx, Dy
 
 
-def arImgDisp_s(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, SearchLimitY, Dx0, Dy0, SubPixFlag,
-                oversample, MultiThread):
+def arImgDisp_s(
+    I1,
+    I2,
+    xGrid,
+    yGrid,
+    ChipSizeX,
+    ChipSizeY,
+    SearchLimitX,
+    SearchLimitY,
+    Dx0,
+    Dy0,
+    SubPixFlag,
+    oversample,
+    MultiThread,
+):
     import numpy as np
     from . import autoriftcore
     import multiprocessing as mp
@@ -1200,24 +1402,24 @@ def arImgDisp_s(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
 
     if np.size(SearchLimitX) == 1:
         if np.logical_not(isinstance(SearchLimitX, np.float32) & isinstance(SearchLimitY, np.float32)):
-            sys.exit('SearchLimit must be float')
+            sys.exit("SearchLimit must be float")
     else:
         if np.logical_not((SearchLimitX.dtype == np.float32) & (SearchLimitY.dtype == np.float32)):
-            sys.exit('SearchLimit must be float')
+            sys.exit("SearchLimit must be float")
 
     if np.size(Dx0) == 1:
         if np.logical_not(isinstance(Dx0, np.float32) & isinstance(Dy0, np.float32)):
-            sys.exit('Search offsets must be float')
+            sys.exit("Search offsets must be float")
     else:
         if np.logical_not((Dx0.dtype == np.float32) & (Dy0.dtype == np.float32)):
-            sys.exit('Search offsets must be float')
+            sys.exit("Search offsets must be float")
 
     if np.size(ChipSizeX) == 1:
         if np.logical_not(isinstance(ChipSizeX, np.float32) & isinstance(ChipSizeY, np.float32)):
-            sys.exit('ChipSize must be float')
+            sys.exit("ChipSize must be float")
     else:
         if np.logical_not((ChipSizeX.dtype == np.float32) & (ChipSizeY.dtype == np.float32)):
-            sys.exit('ChipSize must be float')
+            sys.exit("ChipSize must be float")
 
     if np.any(np.mod(ChipSizeX, 2) != 0) | np.any(np.mod(ChipSizeY, 2) != 0):
         #        if np.any(np.mod(xGrid-0.5,1) == 0) & np.any(np.mod(yGrid-0.5,1) == 0):
@@ -1225,16 +1427,16 @@ def arImgDisp_s(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
         #        else:
         #            xGrid = np.ceil(xGrid)
         #            yGrid = np.ceil(yGrid)
-        sys.exit('it is better to have ChipSize = even number')
+        sys.exit("it is better to have ChipSize = even number")
 
     if np.any(np.mod(SearchLimitX, 1) != 0) | np.any(np.mod(SearchLimitY, 1) != 0):
-        sys.exit('SearchLimit must be an integar value')
+        sys.exit("SearchLimit must be an integar value")
 
     if np.any(SearchLimitX < 0) | np.any(SearchLimitY < 0):
-        sys.exit('SearchLimit cannot be negative')
+        sys.exit("SearchLimit cannot be negative")
 
     if np.any(np.mod(ChipSizeX, 4) != 0) | np.any(np.mod(ChipSizeY, 4) != 0):
-        sys.exit('ChipSize should be evenly divisible by 4')
+        sys.exit("ChipSize should be evenly divisible by 4")
 
     if np.size(Dx0) == 1:
         Dx0 = np.ones(xGrid.shape, dtype=np.float32) * Dx0
@@ -1262,12 +1464,12 @@ def arImgDisp_s(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
     SLy_max = np.max(SearchLimitY + np.abs(Dy0))
     Py = np.int(np.max(ChipSizeY) / 2 + SLy_max + 2)
 
-    I1 = np.lib.pad(I1, ((Py, Py), (Px, Px)), 'constant')
-    I2 = np.lib.pad(I2, ((Py, Py), (Px, Px)), 'constant')
+    I1 = np.lib.pad(I1, ((Py, Py), (Px, Px)), "constant")
+    I2 = np.lib.pad(I2, ((Py, Py), (Px, Px)), "constant")
 
     # adjust center location by the padarray size and 0.5 is added because we need to extract the chip centered at X+1 with -chipsize/2:chipsize/2-1, which equivalently centers at X+0.5 (X is the original grid point location). So for even chipsize, always returns offset estimates at (X+0.5).
-    xGrid += (Px + 0.5)
-    yGrid += (Py + 0.5)
+    xGrid += Px + 0.5
+    yGrid += Py + 0.5
 
     Dx = np.empty(xGrid.shape, dtype=np.float32)
     Dx.fill(np.nan)
@@ -1290,10 +1492,14 @@ def arImgDisp_s(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
                 ChipRangeY = slice(int(-cly - Dy0[ii, jj] + yGrid[ii, jj]), int(cly - Dy0[ii, jj] + yGrid[ii, jj]))
                 ChipI = I2[ChipRangeY, ChipRangeX]
 
-                SearchRangeX = slice(int(-clx - SearchLimitX[ii, jj] + xGrid[ii, jj]),
-                                     int(clx + SearchLimitX[ii, jj] - 1 + xGrid[ii, jj]))
-                SearchRangeY = slice(int(-cly - SearchLimitY[ii, jj] + yGrid[ii, jj]),
-                                     int(cly + SearchLimitY[ii, jj] - 1 + yGrid[ii, jj]))
+                SearchRangeX = slice(
+                    int(-clx - SearchLimitX[ii, jj] + xGrid[ii, jj]),
+                    int(clx + SearchLimitX[ii, jj] - 1 + xGrid[ii, jj]),
+                )
+                SearchRangeY = slice(
+                    int(-cly - SearchLimitY[ii, jj] + yGrid[ii, jj]),
+                    int(cly + SearchLimitY[ii, jj] - 1 + yGrid[ii, jj]),
+                )
                 RefI = I1[SearchRangeY, SearchRangeX]
 
                 minChipI = np.min(ChipI)
@@ -1311,16 +1517,32 @@ def arImgDisp_s(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
                 if SubPixFlag:
                     # call C++
                     Dx1[ii], Dy1[ii] = np.float32(
-                        autoriftcore.arSubPixDisp_s_Py(core._autoriftcore, ChipI.shape[1], ChipI.shape[0],
-                                                       ChipI.ravel(), RefI.shape[1], RefI.shape[0], RefI.ravel(),
-                                                       oversample))
+                        autoriftcore.arSubPixDisp_s_Py(
+                            core._autoriftcore,
+                            ChipI.shape[1],
+                            ChipI.shape[0],
+                            ChipI.ravel(),
+                            RefI.shape[1],
+                            RefI.shape[0],
+                            RefI.ravel(),
+                            oversample,
+                        )
+                    )
                 #                   # call Python
                 #                   Dx1[ii], Dy1[ii] = arSubPixDisp(ChipI,RefI)
                 else:
                     # call C++
                     Dx1[ii], Dy1[ii] = np.float32(
-                        autoriftcore.arPixDisp_s_Py(core._autoriftcore, ChipI.shape[1], ChipI.shape[0], ChipI.ravel(),
-                                                    RefI.shape[1], RefI.shape[0], RefI.ravel()))
+                        autoriftcore.arPixDisp_s_Py(
+                            core._autoriftcore,
+                            ChipI.shape[1],
+                            ChipI.shape[0],
+                            ChipI.ravel(),
+                            RefI.shape[1],
+                            RefI.shape[0],
+                            RefI.ravel(),
+                        )
+                    )
     #                   # call Python
     #                   Dx1[ii], Dy1[ii] = arPixDisp(ChipI,RefI)
     else:
@@ -1331,49 +1553,49 @@ def arImgDisp_s(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
 
         #        import pdb
         #        pdb.set_trace()
-        XI1 = mp.RawArray('f', np.asscalar(np.prod(I_shape)))
+        XI1 = mp.RawArray("f", np.asscalar(np.prod(I_shape)))
         XI1_np = np.frombuffer(XI1, dtype=np.float32).reshape(I_shape)
         np.copyto(XI1_np, I1)
         del I1
 
-        XI2 = mp.RawArray('f', np.asscalar(np.prod(I_shape)))
+        XI2 = mp.RawArray("f", np.asscalar(np.prod(I_shape)))
         XI2_np = np.frombuffer(XI2, dtype=np.float32).reshape(I_shape)
         np.copyto(XI2_np, I2)
         del I2
 
-        XxGrid = mp.RawArray('f', shape_prod)
+        XxGrid = mp.RawArray("f", shape_prod)
         XxGrid_np = np.frombuffer(XxGrid, dtype=np.float32).reshape(in_shape)
         np.copyto(XxGrid_np, xGrid)
         del xGrid
 
-        XyGrid = mp.RawArray('f', shape_prod)
+        XyGrid = mp.RawArray("f", shape_prod)
         XyGrid_np = np.frombuffer(XyGrid, dtype=np.float32).reshape(in_shape)
         np.copyto(XyGrid_np, yGrid)
         del yGrid
 
-        XSearchLimitX = mp.RawArray('f', shape_prod)
+        XSearchLimitX = mp.RawArray("f", shape_prod)
         XSearchLimitX_np = np.frombuffer(XSearchLimitX, dtype=np.float32).reshape(in_shape)
         np.copyto(XSearchLimitX_np, SearchLimitX)
 
-        XSearchLimitY = mp.RawArray('f', shape_prod)
+        XSearchLimitY = mp.RawArray("f", shape_prod)
         XSearchLimitY_np = np.frombuffer(XSearchLimitY, dtype=np.float32).reshape(in_shape)
         np.copyto(XSearchLimitY_np, SearchLimitY)
 
-        XChipSizeX = mp.RawArray('f', shape_prod)
+        XChipSizeX = mp.RawArray("f", shape_prod)
         XChipSizeX_np = np.frombuffer(XChipSizeX, dtype=np.float32).reshape(in_shape)
         np.copyto(XChipSizeX_np, ChipSizeX)
         del ChipSizeX
 
-        XChipSizeY = mp.RawArray('f', shape_prod)
+        XChipSizeY = mp.RawArray("f", shape_prod)
         XChipSizeY_np = np.frombuffer(XChipSizeY, dtype=np.float32).reshape(in_shape)
         np.copyto(XChipSizeY_np, ChipSizeY)
         del ChipSizeY
 
-        XDx0 = mp.RawArray('f', shape_prod)
+        XDx0 = mp.RawArray("f", shape_prod)
         XDx0_np = np.frombuffer(XDx0, dtype=np.float32).reshape(in_shape)
         np.copyto(XDx0_np, Dx0)
 
-        XDy0 = mp.RawArray('f', shape_prod)
+        XDy0 = mp.RawArray("f", shape_prod)
         XDy0_np = np.frombuffer(XDy0, dtype=np.float32).reshape(in_shape)
         np.copyto(XDy0_np, Dy0)
         #        import pdb
@@ -1395,11 +1617,12 @@ def arImgDisp_s(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
             CHUNKS.append(chunkInds)
         #            print(CHUNKS)
 
-        chunk_inputs = [(kk, CHUNKS[kk], SubPixFlag, oversample, in_shape, I_shape)
-                        for kk in range(Nchunks)]
+        chunk_inputs = [(kk, CHUNKS[kk], SubPixFlag, oversample, in_shape, I_shape) for kk in range(Nchunks)]
 
-        with mp.Pool(initializer=initializer, initargs=(
-                XI1, XI2, XxGrid, XyGrid, XSearchLimitX, XSearchLimitY, XChipSizeX, XChipSizeY, XDx0, XDy0)) as pool:
+        with mp.Pool(
+            initializer=initializer,
+            initargs=(XI1, XI2, XxGrid, XyGrid, XSearchLimitX, XSearchLimitY, XChipSizeX, XChipSizeY, XDx0, XDy0),
+        ) as pool:
             Dx, Dy = zip(*pool.map(unpacking_loop_s, chunk_inputs))
 
         Dx = np.concatenate(Dx)
@@ -1411,8 +1634,8 @@ def arImgDisp_s(I1, I2, xGrid, yGrid, ChipSizeX, ChipSizeY, SearchLimitX, Search
     # add back 1) I1 (RefI) relative to I2 (ChipI) initial offset Dx0 and Dy0, and
     #          2) RefI relative to ChipI has a left/top boundary offset of -SearchLimitX and -SearchLimitY
     idx = np.logical_not(np.isnan(Dx))
-    Dx[idx] += (Dx0[idx] - SearchLimitX[idx])
-    Dy[idx] += (Dy0[idx] - SearchLimitY[idx])
+    Dx[idx] += Dx0[idx] - SearchLimitX[idx]
+    Dy[idx] += Dy0[idx] - SearchLimitY[idx]
 
     # convert from matrix X-Y to cartesian X-Y: X no change, Y from down being positive to up being positive
     Dy = -Dy
@@ -1441,29 +1664,57 @@ def colfilt(A, kernelSize, option, chunkSize=4):
             endInds = (ii + 1) * chunkInds
 
         if (ii == 0) & (ii == chunkSize - 1):
-            A1 = np.lib.pad(A[:, startInds:endInds], ((int((kernelSize[0] - 1) / 2), int((kernelSize[0] - 1) / 2)),
-                                                      (int((kernelSize[1] - 1) / 2), int((kernelSize[1] - 1) / 2))),
-                            mode='constant', constant_values=np.nan)
+            A1 = np.lib.pad(
+                A[:, startInds:endInds],
+                (
+                    (int((kernelSize[0] - 1) / 2), int((kernelSize[0] - 1) / 2)),
+                    (int((kernelSize[1] - 1) / 2), int((kernelSize[1] - 1) / 2)),
+                ),
+                mode="constant",
+                constant_values=np.nan,
+            )
         else:
             if ii == 0:
-                A1 = np.lib.pad(A[:, startInds:np.min((endInds + int((kernelSize[1] - 1) / 2), A.shape[1] - 1))], (
-                    (int((kernelSize[0] - 1) / 2), int((kernelSize[0] - 1) / 2)),
-                    (int((kernelSize[1] - 1) / 2),
-                     np.max((0, endInds + int((kernelSize[1] - 1) / 2) - A.shape[1] + 1)))),
-                                mode='constant', constant_values=np.nan)
+                A1 = np.lib.pad(
+                    A[:, startInds : np.min((endInds + int((kernelSize[1] - 1) / 2), A.shape[1] - 1))],
+                    (
+                        (int((kernelSize[0] - 1) / 2), int((kernelSize[0] - 1) / 2)),
+                        (
+                            int((kernelSize[1] - 1) / 2),
+                            np.max((0, endInds + int((kernelSize[1] - 1) / 2) - A.shape[1] + 1)),
+                        ),
+                    ),
+                    mode="constant",
+                    constant_values=np.nan,
+                )
             elif ii == chunkSize - 1:
-                A1 = np.lib.pad(A[:, np.max((0, startInds - int((kernelSize[1] - 1) / 2))):endInds], (
-                    (int((kernelSize[0] - 1) / 2), int((kernelSize[0] - 1) / 2)),
-                    (np.max((0, 0 - startInds + int((kernelSize[1] - 1) / 2))), int((kernelSize[1] - 1) / 2))),
-                                mode='constant', constant_values=np.nan)
+                A1 = np.lib.pad(
+                    A[:, np.max((0, startInds - int((kernelSize[1] - 1) / 2))) : endInds],
+                    (
+                        (int((kernelSize[0] - 1) / 2), int((kernelSize[0] - 1) / 2)),
+                        (np.max((0, 0 - startInds + int((kernelSize[1] - 1) / 2))), int((kernelSize[1] - 1) / 2)),
+                    ),
+                    mode="constant",
+                    constant_values=np.nan,
+                )
             else:
-                A1 = np.lib.pad(A[:, np.max((0, startInds - int((kernelSize[1] - 1) / 2))):np.min(
-                    (endInds + int((kernelSize[1] - 1) / 2), A.shape[1] - 1))], (
-                                    (int((kernelSize[0] - 1) / 2), int((kernelSize[0] - 1) / 2)), (
-                                        np.max((0, 0 - startInds + int((kernelSize[1] - 1) / 2))),
-                                        np.max((0, endInds + int((kernelSize[1] - 1) / 2) - A.shape[1] + 1)))),
-                                mode='constant',
-                                constant_values=np.nan)
+                A1 = np.lib.pad(
+                    A[
+                        :,
+                        np.max((0, startInds - int((kernelSize[1] - 1) / 2))) : np.min(
+                            (endInds + int((kernelSize[1] - 1) / 2), A.shape[1] - 1)
+                        ),
+                    ],
+                    (
+                        (int((kernelSize[0] - 1) / 2), int((kernelSize[0] - 1) / 2)),
+                        (
+                            np.max((0, 0 - startInds + int((kernelSize[1] - 1) / 2))),
+                            np.max((0, endInds + int((kernelSize[1] - 1) / 2) - A.shape[1] + 1)),
+                        ),
+                    ),
+                    mode="constant",
+                    constant_values=np.nan,
+                )
 
         B = viewW(A1, kernelSize).reshape(-1, kernelSize[0] * kernelSize[1]).T[:, ::1]
 
@@ -1513,7 +1764,7 @@ def colfilt(A, kernelSize, option, chunkSize=4):
             del D
             C = C.reshape(output_size)
         else:
-            sys.exit('invalid option for columnwise neighborhood filtering')
+            sys.exit("invalid option for columnwise neighborhood filtering")
 
         C = C.astype(Adtype)
 
@@ -1526,7 +1777,6 @@ def colfilt(A, kernelSize, option, chunkSize=4):
 
 
 class DISP_FILT:
-
     def __init__(self):
         ##filter parameters; try different parameters to decide how much fine-resolution estimates we keep, which can make the final images smoother
 
@@ -1542,24 +1792,27 @@ class DISP_FILT:
         import numpy as np
 
         if np.mod(self.FiltWidth, 2) == 0:
-            sys.exit('NDC filter width must be an odd number')
+            sys.exit("NDC filter width must be an odd number")
 
-        dToleranceX = self.FracValid * self.FiltWidth ** 2
-        dToleranceY = self.FracValid * self.FiltWidth ** 2
+        dToleranceX = self.FracValid * self.FiltWidth**2
+        dToleranceY = self.FracValid * self.FiltWidth**2
         #        pdb.set_trace()
         Dx = Dx / SearchLimitX
         Dy = Dy / SearchLimitY
 
-        DxMadmin = np.ones(Dx.shape) / OverSampleRatio / SearchLimitX * 2;
-        DyMadmin = np.ones(Dy.shape) / OverSampleRatio / SearchLimitY * 2;
+        DxMadmin = np.ones(Dx.shape) / OverSampleRatio / SearchLimitX * 2
+        DyMadmin = np.ones(Dy.shape) / OverSampleRatio / SearchLimitY * 2
 
         for i in range(self.Iter):
             Dx[np.logical_not(M)] = np.nan
             Dy[np.logical_not(M)] = np.nan
-            M = (colfilt(Dx.copy(), (self.FiltWidth, self.FiltWidth), (5, self.FracSearch),
-                         self.colfiltChunkSize) >= dToleranceX) & (
-                        colfilt(Dy.copy(), (self.FiltWidth, self.FiltWidth), (5, self.FracSearch),
-                                self.colfiltChunkSize) >= dToleranceY)
+            M = (
+                colfilt(Dx.copy(), (self.FiltWidth, self.FiltWidth), (5, self.FracSearch), self.colfiltChunkSize)
+                >= dToleranceX
+            ) & (
+                colfilt(Dy.copy(), (self.FiltWidth, self.FiltWidth), (5, self.FracSearch), self.colfiltChunkSize)
+                >= dToleranceY
+            )
 
         #        if self.Iter == 3:
         #            pdb.set_trace()
@@ -1574,8 +1827,11 @@ class DISP_FILT:
             DxM = colfilt(Dx.copy(), (self.FiltWidth, self.FiltWidth), 3, self.colfiltChunkSize)
             DyM = colfilt(Dy.copy(), (self.FiltWidth, self.FiltWidth), 3, self.colfiltChunkSize)
 
-            M = (np.abs(Dx - DxM) <= np.maximum(self.MadScalar * DxMad, DxMadmin)) & (
-                    np.abs(Dy - DyM) <= np.maximum(self.MadScalar * DyMad, DyMadmin)) & M
+            M = (
+                (np.abs(Dx - DxM) <= np.maximum(self.MadScalar * DxMad, DxMadmin))
+                & (np.abs(Dy - DyM) <= np.maximum(self.MadScalar * DyMad, DyMadmin))
+                & M
+            )
 
         return M
 

--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -154,9 +154,9 @@ def _fft_filter(Ix, valid_domain, power_threshold):
     hull = cv2.convexHull(contour, returnPoints=True)
     hull_image = np.zeros(valid_domain.shape, dtype=np.uint8)
     hull_image = cv2.drawContours(hull_image, [hull], -1, 255)
-    corners = cv2.goodFeaturesToTrack(hull_image, 4, 0.33, 1000)[:, 0, :]
+    corners = cv2.goodFeaturesToTrack(hull_image, 4, 0.1, 1000)[:, 0, :]
     if corners.shape[0] < 4:
-        raise ValueError(f"Only {corners[0]} corners found, expecting 4.")
+        raise ValueError(f"Only {corners.shape[0]} corners found, expecting 4.")
 
     along_track, cross_track = _get_slopes(corners)
     print(f"Along track angle is {along_track:.2f} degrees")

--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -59,7 +59,7 @@ def _wallis_filter(image, filter_width):
 
     shifted = _remove_local_mean(image, kernel)
     std = _preprocess_filt_std(image, kernel)
-    std[std == 0] = np.nan
+    std[np.isclose(std, 0.)] = np.nan
     return shifted / std
 
 

--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -160,6 +160,7 @@ def _fft_filter(Ix, valid_domain, power_threshold):
 
     along_track, cross_track = _get_slopes(corners)
     print(f"Along track angle is {along_track:.2f} degrees")
+    print(f"Cross track angle is {cross_track:.2f} degrees")
 
     filter_base = np.zeros((y, x))
     filter_base[center_y_int - 70 : center_y_int + 70, :] = 1
@@ -198,7 +199,8 @@ def _fft_filter(Ix, valid_domain, power_threshold):
 
     sA = np.nansum(P[filter_a == 1])
     sB = np.nansum(P[filter_b == 1])
-    print(sA, sB)
+    print(f"Along track power is {sB:.0f}")
+    print(f"Cross track power is {sA:.0f}")
     if ((sA / sB >= 2) | (sB / sA >= 2)) & ((sA > power_threshold) | (sB > power_threshold)):
         if sA > sB:
             final_filter = filter_a.copy()

--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -278,7 +278,7 @@ class autoRIFT:
         Preprocess images to remove banding perpendicular to the along flight direction by masking in frequency space
         """
         self.I1 = _fft_filter(self.I1, ~self.I1zeroMask, power_threshold=500)
-        #        self.I2 = _fft_filter(self.I1, ~self.I2zeroMask, power_threshold=500)
+        self.I2 = _fft_filter(self.I2, ~self.I2zeroMask, power_threshold=500)
         print("fft done")
 
     def preprocess_db(self):

--- a/netcdf_output.py
+++ b/netcdf_output.py
@@ -1,29 +1,14 @@
 #!/usr/bin/env python3
-
-########
 # Yang Lei, Jet Propulsion Laboratory
 # November 2017
 
 import datetime
 import os
-import subprocess
 
 import netCDF4
 import numpy as np
 import pandas as pd
 
-#def cmdLineParse():
-#    '''
-#    Command line parser.
-#    '''
-#    parser = argparse.ArgumentParser(description="Single-pair InSAR processing of Sentinel-1 data using ISCE modules")
-#
-#    return parser.parse_args()
-
-
-def runCmd(cmd):
-    out = subprocess.getoutput(cmd)
-    return out
 
 def v_error_cal(vx_error, vy_error):
     vx = np.random.normal(0, vx_error, 1000000)
@@ -342,6 +327,23 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     # CHIPSIZEY = np.round(np.clip(CHIPSIZEY, 0, 65535)).astype(np.uint16)
     # INTERPMASK = np.round(np.clip(INTERPMASK, 0, 255)).astype(np.uint8)
 
+    source = f'NASA MEaSUREs ITS_LIVE project. Processed with autoRIFT version ' \
+             f'{IMG_INFO_DICT["autoRIFT_software_version"]}'
+    if IMG_INFO_DICT['mission_img1'].startswith('S'):
+        source += f'. Contains modified Copernicus Sentinel data {IMG_INFO_DICT["date_center"][0:4]}, processed by ESA'
+    if IMG_INFO_DICT['mission_img1'].startswith('L'):
+        source += f'. Landsat-{IMG_INFO_DICT["satellite_img1"]:.0f} images courtesy of the U.S. Geological Survey'
+
+    references = 'When using this data, please acknowledge the source (see global source attribute) and cite:\n' \
+                 '* Gardner, A. S., Moholdt, G., Scambos, T., Fahnestock, M., Ligtenberg, S., van den Broeke, M.,\n' \
+                 '  and Nilsson, J., 2018. Increased West Antarctic and unchanged East Antarctic ice discharge over\n' \
+                 '  the last 7 years. The Cryosphere, 12, p.521. https://doi.org/10.5194/tc-12-521-2018\n' \
+                 '* Lei, Y., Gardner, A. and Agram, P., 2021. Autonomous Repeat Image Feature Tracking (autoRIFT)\n' \
+                 '  and Its Application for Tracking Ice Displacement. Remote Sensing, 13(4), p.749.\n' \
+                 '  https://doi.org/10.3390/rs13040749\n' \
+                 '\n' \
+                 'Additionally, a DOI is provided for the software used to generate this data:\n' \
+                 '* autoRIFT: https://doi.org/10.5281/zenodo.4025445\n' \
 
     tran = [tran[0] + tran[1]/2, tran[1], 0.0, tran[3] + tran[5]/2, 0.0, tran[5]]
 
@@ -354,83 +356,31 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     nc_outfile.setncattr('Conventions', 'CF-1.6')
     nc_outfile.setncattr('date_created', datetime.datetime.now().strftime("%d-%b-%Y %H:%M:%S"))
     nc_outfile.setncattr('title', title)
-    nc_outfile.setncattr('author', author)
-    nc_outfile.setncattr('institution', institution)
-    # nc_outfile.setncattr('Software', version)
+    nc_outfile.setncattr('autoRIFT_software_version', IMG_INFO_DICT["autoRIFT_software_version"])
     nc_outfile.setncattr('scene_pair_type', pair_type)
     nc_outfile.setncattr('motion_detection_method', detection_method)
     nc_outfile.setncattr('motion_coordinates', coordinates)
+    nc_outfile.setncattr('author', author)
+    nc_outfile.setncattr('institution', institution)
+    nc_outfile.setncattr('source', source)
+    nc_outfile.setncattr('references', references)
 
-    # if we were copying from an nc file, we would...
-    # for attr in vv_nc_basefile.ncattrs():
-    #     nc_outfile.setncattr(attr,vv_nc_basefile.getncattr(attr))
-
-    # from topsApp import TopsInSAR
-    # insar = TopsInSAR(name="topsApp")
-    # insar.configure()
-    # master_filename = os.path.basename(insar.master.safe[0])
-    # slave_filename = os.path.basename(insar.slave.safe[0])
-
-    # import topsinsar_filename as tf
-    # master_filename, slave_filename = tf.loadXml()
-
-
-    # runCmd('topsinsar_filename.py')
-    # import scipy.io as sio
-    # conts = sio.loadmat('topsinsar_filename.mat')
-    # master_filename = conts['master_filename'][0]
-    # slave_filename = conts['slave_filename'][0]
-    # master_split = str.split(master_filename,'_')
-    # slave_split = str.split(slave_filename,'_')
 
     var = nc_outfile.createVariable('img_pair_info', 'U1', (), fill_value=None)
-    # variable made, now add attributes
-
-    # var.setncattr('mission_img1',master_split[0][0])
-    # var.setncattr('sensor_img1','C')
-    # var.setncattr('satellite_img1',master_split[0][1:3])
-    # var.setncattr('acquisition_img1',master_split[5][0:8])
-    # var.setncattr('absolute_orbit_number_img1',master_split[7])
-    # var.setncattr('mission_data_take_ID_img1',master_split[8])
-    # var.setncattr('product_unique_ID_img1',master_split[9][0:4])
-    #
-    # var.setncattr('mission_img2',slave_split[0][0])
-    # var.setncattr('sensor_img2','C')
-    # var.setncattr('satellite_img2',slave_split[0][1:3])
-    # var.setncattr('acquisition_img2',slave_split[5][0:8])
-    # var.setncattr('absolute_orbit_number_img2',slave_split[7])
-    # var.setncattr('mission_data_take_ID_img2',slave_split[8])
-    # var.setncattr('product_unique_ID_img2',slave_split[9][0:4])
-    #
-    # from datetime import date
-    # d0 = date(np.int(master_split[5][0:4]),np.int(master_split[5][4:6]),np.int(master_split[5][6:8]))
-    # d1 = date(np.int(slave_split[5][0:4]),np.int(slave_split[5][4:6]),np.int(slave_split[5][6:8]))
-    # date_dt = d1 - d0
-    # var.setncattr('date_dt',np.float64(np.abs(date_dt.days)))
-    # if date_dt.days < 0:
-    #     date_ct = d1 + (d0 - d1)/2
-    #     var.setncattr('date_center',date_ct.strftime("%Y%m%d"))
-    # else:
-    #     date_ct = d0 + (d1 - d0)/2
-    #     var.setncattr('date_center',date_ct.strftime("%Y%m%d"))
-    #  # var.setncattr('date_center',np.abs(np.int(slave_split[5][0:8])+np.int(master_split[5][0:8]))/2)
-    #
-    # var.setncattr('roi_valid_percentage',roi_valid_percentage)
-    # var.setncattr('autoRIFT_software_version',version)
-
     for key in IMG_INFO_DICT:
+        if key == 'autoRIFT_software_version':
+            continue
         var.setncattr(key, IMG_INFO_DICT[key])
 
     # set dimensions
     dimidY, dimidX = VX.shape
     nc_outfile.createDimension('x', dimidX)
     nc_outfile.createDimension('y', dimidY)
-    # pdb.set_trace()
-    x = np.arange(tran[0], tran[0]+tran[1]*dimidX, tran[1])
-    y = np.arange(tran[3], tran[3]+tran[5]*dimidY, tran[5])
-    # pdb.set_trace()
+
+    x = np.arange(tran[0], tran[0] + tran[1] * dimidX, tran[1])
+    y = np.arange(tran[3], tran[3] + tran[5] * dimidY, tran[5])
+
     chunk_lines = np.min([np.ceil(8192/dimidY)*128, dimidY])
-    # ChunkSize = [dimidX, chunk_lines]
     ChunkSize = [chunk_lines, dimidX]
 
 
@@ -1253,6 +1203,7 @@ def netCDF_packaging(VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1
     nc_outfile.sync()  # flush data to disk
     nc_outfile.close()
 
+    return out_nc_filename
 
 
 def rotate_vel2radar(rngind, azmind, vel_x, vel_y, swath_border, swath_border_full, GridSpacingX, ScaleChipSizeY, flag):

--- a/testGeogridOptical.py
+++ b/testGeogridOptical.py
@@ -105,6 +105,9 @@ def coregisterLoadMetadata(indir_m, indir_s):
     elif re.findall("L[EO]07_",DS.GetDescription()).__len__() > 0:
         nameString = os.path.basename(DS.GetDescription())
         info.time = nameString.split('_')[3]
+    elif re.findall("LT0[45]_",DS.GetDescription()).__len__() > 0:
+        nameString = os.path.basename(DS.GetDescription())
+        info.time = nameString.split('_')[3]
     elif re.findall("S2._",DS.GetDescription()).__len__() > 0:
         info.time = DS.GetDescription().split('_')[2]
     else:
@@ -123,6 +126,9 @@ def coregisterLoadMetadata(indir_m, indir_s):
         nameString1 = os.path.basename(DS1.GetDescription())
         info1.time = nameString1.split('_')[3]
     elif re.findall("L[EO]07_",DS1.GetDescription()).__len__() > 0:
+        nameString1 = os.path.basename(DS1.GetDescription())
+        info1.time = nameString1.split('_')[3]
+    elif re.findall("LT0[45]_",DS1.GetDescription()).__len__() > 0:
         nameString1 = os.path.basename(DS1.GetDescription())
         info1.time = nameString1.split('_')[3]
     elif re.findall("S2._",DS1.GetDescription()).__len__() > 0:

--- a/testGeogrid_ISCE.py
+++ b/testGeogrid_ISCE.py
@@ -173,7 +173,9 @@ def coregisterLoadMetadataOptical(indir_m, indir_s):
         nameString = os.path.basename(DS.GetDescription())
         info.time = nameString.split('_')[3]
     elif re.findall("L[EO]07_",DS.GetDescription()).__len__() > 0:
-         #pdb.set_trace()
+        nameString = os.path.basename(DS.GetDescription())
+        info.time = nameString.split('_')[3]
+    elif re.findall("LT0[45]_",DS.GetDescription()).__len__() > 0:
         nameString = os.path.basename(DS.GetDescription())
         info.time = nameString.split('_')[3]
     elif re.findall("S2._",DS.GetDescription()).__len__() > 0:
@@ -194,6 +196,9 @@ def coregisterLoadMetadataOptical(indir_m, indir_s):
         nameString1 = os.path.basename(DS1.GetDescription())
         info1.time = nameString1.split('_')[3]
     elif re.findall("L[EO]07_",DS1.GetDescription()).__len__() > 0:
+        nameString1 = os.path.basename(DS1.GetDescription())
+        info1.time = nameString1.split('_')[3]
+    elif re.findall("LT0[45]_",DS1.GetDescription()).__len__() > 0:
         nameString1 = os.path.basename(DS1.GetDescription())
         info1.time = nameString1.split('_')[3]
     elif re.findall("S2._",DS1.GetDescription()).__len__() > 0:

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -146,10 +146,9 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
 
     obj = autoRIFT()
+    # obj.configure()
 
     obj.WallisFilterWidth = preprocessing_filter_width
-
-#    obj.configure()
 
 #    ##########     uncomment if starting from preprocessed images
 #    I1 = I1.astype(np.uint8)

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -149,6 +149,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     # obj.configure()
 
     obj.WallisFilterWidth = preprocessing_filter_width
+    print(f'Setting Wallis Filter Width to {preprocessing_filter_width}')
 
 #    ##########     uncomment if starting from preprocessed images
 #    I1 = I1.astype(np.uint8)
@@ -524,9 +525,10 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
         # FIXME: Filter width is a magic variable here and not exposed well.
         preprocessing_filter_width = 5
-        for ii, name in enumerate((m_name, s_name)):
-            if len(re.findall("S1[AB]_", name)) > 0:
-                preprocessing_filter_width = 21
+        if nc_sensor == 'S1':
+            preprocessing_filter_width = 21
+
+        print(f'Preprocessing filter width {preprocessing_filter_width}')
 
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
@@ -539,10 +541,11 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
         print(f'Using preprocessing methods {preprocessing_methods}')
 
-        Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
-            data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
-            noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info, preprocessing_methods=preprocessing_methods,
-            preprocessing_filter_width=preprocessing_filter_width,
+        Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = \
+            runAutorift(
+                data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
+                noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info,
+                preprocessing_methods=preprocessing_methods, preprocessing_filter_width=preprocessing_filter_width,
         )
         if nc_sensor is not None:
             import netcdf_output as no
@@ -629,7 +632,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
 
         if offset2vx is not None:
-        
+
             ds = gdal.Open(scale_factor)
             band = ds.GetRasterBand(1)
             scale_factor_1 = band.ReadAsArray()

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -290,6 +290,8 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
         obj.preprocess_filt_wal_nodata_fill()
     elif 'wallis' in preprocessing_methods:
         obj.preprocess_filt_wal()
+    elif 'fft' in preprocessing_methods:
+        obj.preprocess_filt_fft()
     else:
         obj.preprocess_filt_hps()
 #    obj.I1 = np.abs(I1)
@@ -515,6 +517,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
                 if acquisition >= datetime(2003, 5, 31):
                     preprocessing_methods[ii] = 'wallis_fill'
+            elif len(re.findall("L[TM]0[45]_", name)) > 0:
+                preprocessing_methods[ii] = 'fft'
 
         print(f'Using preprocessing methods {preprocessing_methods}')
 

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -46,6 +46,8 @@ def cmdLineParse():
     '''
     import argparse
 
+    SUPPORTED_MISSIONS = ['S1', 'S2', 'L4', 'L5', 'L7', 'L8', 'L9']
+
     parser = argparse.ArgumentParser(description='Output geo grid')
     parser.add_argument('-m', '--input_m', dest='indir_m', type=str, required=True,
             help='Input master image file name (in ISCE format and radar coordinates) or Input master image file name (in GeoTIFF format and Cartesian coordinates)')
@@ -71,8 +73,8 @@ def cmdLineParse():
             help='Input stable surface mask file name')
     parser.add_argument('-fo', '--flag_optical', dest='optical_flag', type=bool, required=False, default=0,
             help='flag for reading optical data (e.g. Landsat): use 1 for on and 0 (default) for off')
-    parser.add_argument('-nc', '--sensor_flag_netCDF', dest='nc_sensor', type=str, required=False, default=None,
-            help='flag for packaging output formatted for Sentinel ("S") and Landsat ("L") dataset; default is None')
+    parser.add_argument('-nc', '--sensor_flag_netCDF', dest='nc_sensor', type=str, required=False, default=None, choices=SUPPORTED_MISSIONS,
+            help=f'flag for packaging output formatted for Satellite missions. Default is None; supported missions: {SUPPORTED_MISSIONS}')
     parser.add_argument('-mpflag', '--mpflag', dest='mpflag', type=int, required=False, default=0,
             help='number of threads for multiple threading (default is specified by 0, which uses the original single-core version and surpasses the multithreading routine)')
     parser.add_argument('-ncname', '--ncname', dest='ncname', type=str, required=False, default=None,
@@ -808,7 +810,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
             ########################################################################################
                 ############   netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
-                if nc_sensor == "S":
+                if nc_sensor == "S1":
                     if geogrid_run_info is None:
                         chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         gridspacingx = float(str.split(runCmd('fgrep "Grid spacing in m:" testGeogrid.txt'))[-1])
@@ -903,107 +905,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
                     )
 
-                elif nc_sensor == "L":
-                    if geogrid_run_info is None:
-                        chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
-                        gridspacingx = float(str.split(runCmd('fgrep "Grid spacing in m:" testGeogrid.txt'))[-1])
-                        XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
-                        YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
-                        epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
-                    else:
-                        chipsizex0 = geogrid_run_info['chipsizex0']
-                        gridspacingx = geogrid_run_info['gridspacingx']
-                        XPixelSize = geogrid_run_info['XPixelSize']
-                        YPixelSize = geogrid_run_info['YPixelSize']
-                        epsg = geogrid_run_info['epsg']
-
-                    master_path = indir_m
-                    slave_path = indir_s
-
-                    master_filename = os.path.basename(master_path)
-                    slave_filename = os.path.basename(slave_path)
-
-                    master_split = str.split(master_filename,'_')
-                    slave_split = str.split(slave_filename,'_')
-
-#                    master_MTL_path = master_path[:-6]+'MTL.txt'
-#                    slave_MTL_path = slave_path[:-6]+'MTL.txt'
-#
-#                    master_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+master_MTL_path))[2][1:-2],':')
-#                    slave_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+slave_MTL_path))[2][1:-2],':')
-
-                    import netcdf_output as no
-                    pair_type = 'optical'
-                    detection_method = 'feature'
-                    coordinates = 'map'
-                    if np.sum(SEARCHLIMITX!=0)!=0:
-                        roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
-                    else:
-                        raise Exception('Input search range is all zero everywhere, thus no search conducted')
-    #                out_nc_filename = 'Jakobshavn_opt.nc'
-                    PPP = roi_valid_percentage * 100
-                    if ncname is None:
-                        out_nc_filename = f"./{master_filename[0:-7]}_X_{slave_filename[0:-7]}" \
-                                          f"_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
-                    else:
-                        out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
-                    CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
-
-                    d0 = datetime(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
-                    d1 = datetime(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
-                    date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
-                    date_dt = np.float64(date_dt_base)
-                    if date_dt < 0:
-                        raise Exception('Input image 1 must be older than input image 2')
-
-                    date_ct = d0 + (d1 - d0)/2
-                    date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
-
-                    master_dt = d0.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
-                    slave_dt = d1.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
-
-                    IMG_INFO_DICT = {
-                        'acquisition_date_img1': master_dt,
-                        'acquisition_date_img2': slave_dt,
-                        'collection_category_img1': master_split[6],
-                        'collection_category_img2': slave_split[6],
-                        'collection_number_img1': np.float64(master_split[5]),
-                        'collection_number_img2': np.float64(slave_split[5]),
-                        'correction_level_img1': master_split[1],
-                        'correction_level_img2': slave_split[1],
-                        'mission_img1': master_split[0][0],
-                        'mission_img2': slave_split[0][0],
-                        'path_img1': np.float64(master_split[2][0:3]),
-                        'path_img2': np.float64(slave_split[2][0:3]),
-                        'processing_date_img1': master_split[4][0:8],
-                        'processing_date_img2': slave_split[4][0:8],
-                        'row_img1': np.float64(master_split[2][3:6]),
-                        'row_img2': np.float64(slave_split[2][3:6]),
-                        'satellite_img1': np.float64(master_split[0][2:4]),
-                        'satellite_img2': np.float64(slave_split[0][2:4]),
-                        'sensor_img1': master_split[0][1],
-                        'sensor_img2': slave_split[0][1],
-                        'time_standard_img1': 'UTC',
-                        'time_standard_img2': 'UTC',
-                        'date_center': date_center,
-                        'date_dt': date_dt,
-                        'latitude': cen_lat,
-                        'longitude': cen_lon,
-                        'roi_valid_percentage': PPP,
-                        'autoRIFT_software_version': version
-                    }
-
-                    error_vector = np.array([25.5,25.5])
-
-                    netcdf_file = no.netCDF_packaging(
-                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1, SX, SY,
-                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, None, None, scale_factor_1, scale_factor_2, MM, VXref, VYref,
-                        None, None, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
-                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
-                    )
-
-                elif nc_sensor in ("L7", "L5", "L4"):
+                elif nc_sensor in ("L4", "L5", "L7", "L8", "L9"):
                     if geogrid_run_info is None:
                         chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         gridspacingx = float(str.split(runCmd('fgrep "Grid spacing in m:" testGeogrid.txt'))[-1])

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -685,7 +685,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
             if nc_sensor is not None:
 
-                if nc_sensor == "S":
+                if nc_sensor == "S1":
                     swath_offset_bias_ref = [-0.01, 0.019, -0.0068, 0.006]
                     import netcdf_output as no
                     DX, DY, flight_direction_m, flight_direction_s = no.cal_swath_offset_bias(indir_m, xGrid, yGrid, VX, VY, DX, DY, nodata, tran, proj, GridSpacingX, ScaleChipSizeY, swath_offset_bias_ref)

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -204,9 +204,6 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
                     if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
                         noDataMask[ii,jj] = True
 
-
-
-
     ######### mask out nodata to skip the offset searching using the nodata mask (by setting SearchLimit to be 0)
 
     if SRx0 is None:
@@ -242,14 +239,13 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
         obj.ChipSize0X = int(np.ceil(chipsizex0/pixsizex/4)*4)
         obj.GridSpacingX = int(obj.ChipSize0X*gridspacingx/chipsizex0)
 
-#        obj.ChipSize0X = np.min(CSMINx0[CSMINx0!=nodata])
+        # obj.ChipSize0X = np.min(CSMINx0[CSMINx0!=nodata])
         RATIO_Y2X = CSMINy0/CSMINx0
         obj.ScaleChipSizeY = np.median(RATIO_Y2X[(CSMINx0!=nodata)&(CSMINy0!=nodata)])
-#        obj.ChipSizeMaxX = obj.ChipSizeMaxX / obj.ChipSizeMaxX * 544
-#        obj.ChipSizeMinX = obj.ChipSizeMinX / obj.ChipSizeMinX * 68
+        # obj.ChipSizeMaxX = obj.ChipSizeMaxX / obj.ChipSizeMaxX * 544
+        # obj.ChipSizeMinX = obj.ChipSizeMinX / obj.ChipSizeMinX * 68
     else:
         if ((optflag == 1)&(xGrid is not None)):
-#            print('test')
             obj.ChipSizeMaxX = 32
             obj.ChipSizeMinX = 16
             obj.ChipSize0X = 16
@@ -1067,30 +1063,30 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     slave_dt = d1.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
 
                     IMG_INFO_DICT = {
-                        'mission_img1': master_split[0][0],
-                        'sensor_img1': master_split[0][1],
-                        'satellite_img1': np.float64(master_split[0][2:4]),
-                        'correction_level_img1': master_split[1],
-                        'path_img1': np.float64(master_split[2][0:3]),
-                        'row_img1': np.float64(master_split[2][3:6]),
                         'acquisition_date_img1': master_dt,
-                        'time_standard_img1': 'UTC',
-                        'processing_date_img1': master_split[4][0:8],
-                        'collection_number_img1': np.float64(master_split[5]),
-                        'collection_category_img1': master_split[6],
-                        'mission_img2': slave_split[0][0],
-                        'sensor_img2': slave_split[0][1],
-                        'satellite_img2': np.float64(slave_split[0][2:4]),
-                        'correction_level_img2': slave_split[1],
-                        'path_img2': np.float64(slave_split[2][0:3]),
-                        'row_img2': np.float64(slave_split[2][3:6]),
                         'acquisition_date_img2': slave_dt,
-                        'time_standard_img2': 'UTC',
-                        'processing_date_img2': slave_split[4][0:8],
-                        'collection_number_img2': np.float64(slave_split[5]),
+                        'collection_category_img1': master_split[6],
                         'collection_category_img2': slave_split[6],
-                        'date_dt': date_dt,
+                        'collection_number_img1': np.float64(master_split[5]),
+                        'collection_number_img2': np.float64(slave_split[5]),
+                        'correction_level_img1': master_split[1],
+                        'correction_level_img2': slave_split[1],
+                        'mission_img1': master_split[0][0],
+                        'mission_img2': slave_split[0][0],
+                        'path_img1': np.float64(master_split[2][0:3]),
+                        'path_img2': np.float64(slave_split[2][0:3]),
+                        'processing_date_img1': master_split[4][0:8],
+                        'processing_date_img2': slave_split[4][0:8],
+                        'row_img1': np.float64(master_split[2][3:6]),
+                        'row_img2': np.float64(slave_split[2][3:6]),
+                        'satellite_img1': np.float64(master_split[0][2:4]),
+                        'satellite_img2': np.float64(slave_split[0][2:4]),
+                        'sensor_img1': master_split[0][1],
+                        'sensor_img2': slave_split[0][1],
+                        'time_standard_img1': 'UTC',
+                        'time_standard_img2': 'UTC',
                         'date_center': date_center,
+                        'date_dt': date_dt,
                         'latitude': cen_lat,
                         'longitude': cen_lon,
                         'roi_valid_percentage': PPP,

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -27,6 +27,7 @@
 # Author: Yang Lei
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import re
+import warnings
 from osgeo import gdal
 from datetime import datetime, timedelta
 
@@ -291,7 +292,15 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     elif 'wallis' in preprocessing_methods:
         obj.preprocess_filt_wal()
     elif 'fft' in preprocessing_methods:
-        obj.preprocess_filt_fft()
+        # FIXME: The Landsat 4/5 FFT preprocessor looks for the image corners to
+        #        determine the scene rotation, but Geogrid + autoRIFT rond the
+        #        corners when co-registering and chop the non-overlapping corners
+        #        when subsetting to the common image overlap. FFT filer needs to
+        #        be applied to the native images before they are processed by
+        #        Geogrid or autoRIFT.
+        # obj.preprocess_filt_wal()
+        # obj.preprocess_filt_fft()
+        warnings.warn('FFT filtering must be done before processing with geogrid! Be careful when using this method', UserWarning)
     else:
         obj.preprocess_filt_hps()
 #    obj.I1 = np.abs(I1)
@@ -517,7 +526,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
                 if acquisition >= datetime(2003, 5, 31):
                     preprocessing_methods[ii] = 'wallis_fill'
-            elif len(re.findall("L[TM]0[45]_", name)) > 0:
+            elif len(re.findall("LT0[45]_", name)) > 0:
                 preprocessing_methods[ii] = 'fft'
 
         print(f'Using preprocessing methods {preprocessing_methods}')
@@ -998,7 +1007,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
                     )
 
-                elif nc_sensor == "L7":
+                elif nc_sensor in ("L7", "L5", "L4"):
                     if geogrid_run_info is None:
                         chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         gridspacingx = float(str.split(runCmd('fgrep "Grid spacing in m:" testGeogrid.txt'))[-1])

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -130,7 +130,8 @@ def loadProductOptical(file_m, file_s):
 
 
 def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag,
-                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps')):
+                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps'),
+                preprocessing_filter_width=5):
     '''
     Wire and run geogrid.
     '''
@@ -145,6 +146,9 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
 
     obj = autoRIFT()
+
+    obj.WallisFilterWidth = preprocessing_filter_width
+
 #    obj.configure()
 
 #    ##########     uncomment if starting from preprocessed images
@@ -281,6 +285,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     ######## preprocessing
     t1 = time.time()
     print("Pre-process Start!!!")
+    print(f"Using Wallis Filter Width: {obj.WallisFilterWidth}")
 #    obj.zeroMask = 1
 
     # TODO: Allow different filters to be applied images independently
@@ -518,6 +523,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         m_name = os.path.basename(indir_m)
         s_name = os.path.basename(indir_s)
 
+        # FIXME: Filter width is a magic variable here and not exposed well.
+        preprocessing_filter_width = 5
+        for ii, name in enumerate((m_name, s_name)):
+            if len(re.findall("S1[AB]_", name)) > 0:
+                preprocessing_filter_width = 21
+
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
             if len(re.findall("L[EO]07_", name)) > 0:
@@ -532,6 +543,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
             data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
             noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info, preprocessing_methods=preprocessing_methods,
+            preprocessing_filter_width=preprocessing_filter_width,
         )
         if nc_sensor is not None:
             import netcdf_output as no

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -46,6 +46,8 @@ def cmdLineParse():
     '''
     import argparse
 
+    SUPPORTED_MISSIONS = ['S1', 'S2', 'L4', 'L5', 'L7', 'L8', 'L9']
+
     parser = argparse.ArgumentParser(description='Output geo grid')
     parser.add_argument('-m', '--input_m', dest='indir_m', type=str, required=True,
             help='Input master image file name (in ISCE format and radar coordinates) or Input master image file name (in GeoTIFF format and Cartesian coordinates)')
@@ -71,8 +73,8 @@ def cmdLineParse():
             help='Input stable surface mask file name')
     parser.add_argument('-fo', '--flag_optical', dest='optical_flag', type=bool, required=False, default=0,
             help='flag for reading optical data (e.g. Landsat): use 1 for on and 0 (default) for off')
-    parser.add_argument('-nc', '--sensor_flag_netCDF', dest='nc_sensor', type=str, required=False, default=None,
-            help='flag for packaging output formatted for Sentinel ("S") and Landsat ("L") dataset; default is None')
+    parser.add_argument('-nc', '--sensor_flag_netCDF', dest='nc_sensor', type=str, required=False, default=None, choices=SUPPORTED_MISSIONS,
+            help=f'flag for packaging output formatted for Satellite missions. Default is None; supported missions: {SUPPORTED_MISSIONS}')
     parser.add_argument('-mpflag', '--mpflag', dest='mpflag', type=int, required=False, default=0,
             help='number of threads for multiple threading (default is specified by 0, which uses the original single-core version and surpasses the multithreading routine)')
     parser.add_argument('-ncname', '--ncname', dest='ncname', type=str, required=False, default=None,
@@ -807,7 +809,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
             ########################################################################################
                 ############   netCDF packaging for Sentinel and Landsat dataset; can add other sensor format as well
-                if nc_sensor == "S":
+                if nc_sensor == "S1":
                     if geogrid_run_info is None:
                         chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         gridspacingx = float(str.split(runCmd('fgrep "Grid spacing in m:" testGeogrid.txt'))[-1])
@@ -902,107 +904,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
                     )
 
-                elif nc_sensor == "L":
-                    if geogrid_run_info is None:
-                        chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
-                        gridspacingx = float(str.split(runCmd('fgrep "Grid spacing in m:" testGeogrid.txt'))[-1])
-                        XPixelSize = float(str.split(runCmd('fgrep "X-direction pixel size:" testGeogrid.txt'))[3])
-                        YPixelSize = float(str.split(runCmd('fgrep "Y-direction pixel size:" testGeogrid.txt'))[3])
-                        epsg = float(str.split(runCmd('fgrep "EPSG:" testGeogrid.txt'))[1])
-                    else:
-                        chipsizex0 = geogrid_run_info['chipsizex0']
-                        gridspacingx = geogrid_run_info['gridspacingx']
-                        XPixelSize = geogrid_run_info['XPixelSize']
-                        YPixelSize = geogrid_run_info['YPixelSize']
-                        epsg = geogrid_run_info['epsg']
-
-                    master_path = indir_m
-                    slave_path = indir_s
-
-                    master_filename = os.path.basename(master_path)
-                    slave_filename = os.path.basename(slave_path)
-
-                    master_split = str.split(master_filename,'_')
-                    slave_split = str.split(slave_filename,'_')
-
-#                    master_MTL_path = master_path[:-6]+'MTL.txt'
-#                    slave_MTL_path = slave_path[:-6]+'MTL.txt'
-#
-#                    master_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+master_MTL_path))[2][1:-2],':')
-#                    slave_time = str.split(str.split(runCmd('fgrep "SCENE_CENTER_TIME" '+slave_MTL_path))[2][1:-2],':')
-
-                    import netcdf_output as no
-                    pair_type = 'optical'
-                    detection_method = 'feature'
-                    coordinates = 'map'
-                    if np.sum(SEARCHLIMITX!=0)!=0:
-                        roi_valid_percentage = int(round(np.sum(CHIPSIZEX!=0)/np.sum(SEARCHLIMITX!=0)*1000.0))/1000
-                    else:
-                        raise Exception('Input search range is all zero everywhere, thus no search conducted')
-    #                out_nc_filename = 'Jakobshavn_opt.nc'
-                    PPP = roi_valid_percentage * 100
-                    if ncname is None:
-                        out_nc_filename = f"./{master_filename[0:-7]}_X_{slave_filename[0:-7]}" \
-                                          f"_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
-                    else:
-                        out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
-                    CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
-
-                    d0 = datetime(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
-                    d1 = datetime(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
-                    date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
-                    date_dt = np.float64(date_dt_base)
-                    if date_dt < 0:
-                        raise Exception('Input image 1 must be older than input image 2')
-
-                    date_ct = d0 + (d1 - d0)/2
-                    date_center = date_ct.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
-
-                    master_dt = d0.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
-                    slave_dt = d1.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
-
-                    IMG_INFO_DICT = {
-                        'acquisition_date_img1': master_dt,
-                        'acquisition_date_img2': slave_dt,
-                        'collection_category_img1': master_split[6],
-                        'collection_category_img2': slave_split[6],
-                        'collection_number_img1': np.float64(master_split[5]),
-                        'collection_number_img2': np.float64(slave_split[5]),
-                        'correction_level_img1': master_split[1],
-                        'correction_level_img2': slave_split[1],
-                        'mission_img1': master_split[0][0],
-                        'mission_img2': slave_split[0][0],
-                        'path_img1': np.float64(master_split[2][0:3]),
-                        'path_img2': np.float64(slave_split[2][0:3]),
-                        'processing_date_img1': master_split[4][0:8],
-                        'processing_date_img2': slave_split[4][0:8],
-                        'row_img1': np.float64(master_split[2][3:6]),
-                        'row_img2': np.float64(slave_split[2][3:6]),
-                        'satellite_img1': np.float64(master_split[0][2:4]),
-                        'satellite_img2': np.float64(slave_split[0][2:4]),
-                        'sensor_img1': master_split[0][1],
-                        'sensor_img2': slave_split[0][1],
-                        'time_standard_img1': 'UTC',
-                        'time_standard_img2': 'UTC',
-                        'date_center': date_center,
-                        'date_dt': date_dt,
-                        'latitude': cen_lat,
-                        'longitude': cen_lon,
-                        'roi_valid_percentage': PPP,
-                        'autoRIFT_software_version': version
-                    }
-
-                    error_vector = np.array([25.5,25.5])
-
-                    netcdf_file = no.netCDF_packaging(
-                        VX, VY, DX, DY, INTERPMASK, CHIPSIZEX, CHIPSIZEY, SSM, SSM1, SX, SY,
-                        offset2vx_1, offset2vx_2, offset2vy_1, offset2vy_2, None, None, scale_factor_1, scale_factor_2, MM, VXref, VYref,
-                        None, None, XPixelSize, YPixelSize, None, epsg, srs, tran, out_nc_filename, pair_type,
-                        detection_method, coordinates, IMG_INFO_DICT, stable_count, stable_count1, stable_shift_applied,
-                        dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
-                    )
-
-                elif nc_sensor in ("L7", "L5", "L4"):
+                elif nc_sensor in ("L4", "L5", "L7", "L8", "L9"):
                     if geogrid_run_info is None:
                         chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         gridspacingx = float(str.split(runCmd('fgrep "Grid spacing in m:" testGeogrid.txt'))[-1])

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -203,9 +203,6 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
                     if (I1[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0)|(I2[obj.yGrid[ii,jj]-1,obj.xGrid[ii,jj]-1]==0):
                         noDataMask[ii,jj] = True
 
-
-
-
     ######### mask out nodata to skip the offset searching using the nodata mask (by setting SearchLimit to be 0)
 
     if SRx0 is None:
@@ -241,14 +238,13 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
         obj.ChipSize0X = int(np.ceil(chipsizex0/pixsizex/4)*4)
         obj.GridSpacingX = int(obj.ChipSize0X*gridspacingx/chipsizex0)
 
-#        obj.ChipSize0X = np.min(CSMINx0[CSMINx0!=nodata])
+        # obj.ChipSize0X = np.min(CSMINx0[CSMINx0!=nodata])
         RATIO_Y2X = CSMINy0/CSMINx0
         obj.ScaleChipSizeY = np.median(RATIO_Y2X[(CSMINx0!=nodata)&(CSMINy0!=nodata)])
-#        obj.ChipSizeMaxX = obj.ChipSizeMaxX / obj.ChipSizeMaxX * 544
-#        obj.ChipSizeMinX = obj.ChipSizeMinX / obj.ChipSizeMinX * 68
+        # obj.ChipSizeMaxX = obj.ChipSizeMaxX / obj.ChipSizeMaxX * 544
+        # obj.ChipSizeMinX = obj.ChipSizeMinX / obj.ChipSizeMinX * 68
     else:
         if ((optflag == 1)&(xGrid is not None)):
-#            print('test')
             obj.ChipSizeMaxX = 32
             obj.ChipSizeMinX = 16
             obj.ChipSize0X = 16
@@ -1066,30 +1062,30 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                     slave_dt = d1.strftime("%Y%m%dT%H:%M:%S.%f").rstrip('0')
 
                     IMG_INFO_DICT = {
-                        'mission_img1': master_split[0][0],
-                        'sensor_img1': master_split[0][1],
-                        'satellite_img1': np.float64(master_split[0][2:4]),
-                        'correction_level_img1': master_split[1],
-                        'path_img1': np.float64(master_split[2][0:3]),
-                        'row_img1': np.float64(master_split[2][3:6]),
                         'acquisition_date_img1': master_dt,
-                        'time_standard_img1': 'UTC',
-                        'processing_date_img1': master_split[4][0:8],
-                        'collection_number_img1': np.float64(master_split[5]),
-                        'collection_category_img1': master_split[6],
-                        'mission_img2': slave_split[0][0],
-                        'sensor_img2': slave_split[0][1],
-                        'satellite_img2': np.float64(slave_split[0][2:4]),
-                        'correction_level_img2': slave_split[1],
-                        'path_img2': np.float64(slave_split[2][0:3]),
-                        'row_img2': np.float64(slave_split[2][3:6]),
                         'acquisition_date_img2': slave_dt,
-                        'time_standard_img2': 'UTC',
-                        'processing_date_img2': slave_split[4][0:8],
-                        'collection_number_img2': np.float64(slave_split[5]),
+                        'collection_category_img1': master_split[6],
                         'collection_category_img2': slave_split[6],
-                        'date_dt': date_dt,
+                        'collection_number_img1': np.float64(master_split[5]),
+                        'collection_number_img2': np.float64(slave_split[5]),
+                        'correction_level_img1': master_split[1],
+                        'correction_level_img2': slave_split[1],
+                        'mission_img1': master_split[0][0],
+                        'mission_img2': slave_split[0][0],
+                        'path_img1': np.float64(master_split[2][0:3]),
+                        'path_img2': np.float64(slave_split[2][0:3]),
+                        'processing_date_img1': master_split[4][0:8],
+                        'processing_date_img2': slave_split[4][0:8],
+                        'row_img1': np.float64(master_split[2][3:6]),
+                        'row_img2': np.float64(slave_split[2][3:6]),
+                        'satellite_img1': np.float64(master_split[0][2:4]),
+                        'satellite_img2': np.float64(slave_split[0][2:4]),
+                        'sensor_img1': master_split[0][1],
+                        'sensor_img2': slave_split[0][1],
+                        'time_standard_img1': 'UTC',
+                        'time_standard_img2': 'UTC',
                         'date_center': date_center,
+                        'date_dt': date_dt,
                         'latitude': cen_lat,
                         'longitude': cen_lon,
                         'roi_valid_percentage': PPP,

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -27,6 +27,7 @@
 # Author: Yang Lei
 #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import re
+import warnings
 from osgeo import gdal
 from datetime import datetime, timedelta
 
@@ -290,7 +291,15 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     elif 'wallis' in preprocessing_methods:
         obj.preprocess_filt_wal()
     elif 'fft' in preprocessing_methods:
-        obj.preprocess_filt_fft()
+        # FIXME: The Landsat 4/5 FFT preprocessor looks for the image corners to
+        #        determine the scene rotation, but Geogrid + autoRIFT rond the
+        #        corners when co-registering and chop the non-overlapping corners
+        #        when subsetting to the common image overlap. FFT filer needs to
+        #        be applied to the native images before they are processed by
+        #        Geogrid or autoRIFT.
+        # obj.preprocess_filt_wal()
+        # obj.preprocess_filt_fft()
+        warnings.warn('FFT filtering must be done before processing with geogrid! Be careful when using this method', UserWarning)
     else:
         obj.preprocess_filt_hps()
 #    obj.I1 = np.abs(I1)
@@ -516,7 +525,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
                 if acquisition >= datetime(2003, 5, 31):
                     preprocessing_methods[ii] = 'wallis_fill'
-            elif len(re.findall("L[TM]0[45]_", name)) > 0:
+            elif len(re.findall("LT0[45]_", name)) > 0:
                 preprocessing_methods[ii] = 'fft'
 
         print(f'Using preprocessing methods {preprocessing_methods}')
@@ -997,7 +1006,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         dx_mean_shift, dy_mean_shift, dx_mean_shift1, dy_mean_shift1, error_vector
                     )
 
-                elif nc_sensor == "L7":
+                elif nc_sensor in ("L7", "L5", "L4"):
                     if geogrid_run_info is None:
                         chipsizex0 = float(str.split(runCmd('fgrep "Smallest Allowable Chip Size in m:" testGeogrid.txt'))[-1])
                         gridspacingx = float(str.split(runCmd('fgrep "Grid spacing in m:" testGeogrid.txt'))[-1])

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -130,7 +130,8 @@ def loadProductOptical(file_m, file_s):
 
 
 def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0, noDataMask, optflag,
-                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps')):
+                nodata, mpflag, geogrid_run_info=None, preprocessing_methods=('hps', 'hps'),
+                preprocessing_filter_width=5):
     '''
     Wire and run geogrid.
     '''
@@ -280,6 +281,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     ######## preprocessing
     t1 = time.time()
     print("Pre-process Start!!!")
+    print(f"Using Wallis Filter Width: {obj.WallisFilterWidth}")
 #    obj.zeroMask = 1
 
     # TODO: Allow different filters to be applied images independently
@@ -517,6 +519,12 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         m_name = os.path.basename(indir_m)
         s_name = os.path.basename(indir_s)
 
+        # FIXME: Filter width is a magic variable here and not exposed well.
+        preprocessing_filter_width = 5
+        for ii, name in enumerate((m_name, s_name)):
+            if len(re.findall("S1[AB]_", name)) > 0:
+                preprocessing_filter_width = 21
+
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
             if len(re.findall("L[EO]07_", name)) > 0:
@@ -531,6 +539,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
         Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
             data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
             noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info, preprocessing_methods=preprocessing_methods,
+            preprocessing_filter_width=preprocessing_filter_width,
         )
         if nc_sensor is not None:
             import netcdf_output as no

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -684,7 +684,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
             if nc_sensor is not None:
 
-                if nc_sensor == "S":
+                if nc_sensor == "S1":
                     swath_offset_bias_ref = [-0.01, 0.019, -0.0068, 0.006]
                     import netcdf_output as no
                     DX, DY, flight_direction_m, flight_direction_s = no.cal_swath_offset_bias(indir_m, xGrid, yGrid, VX, VY, DX, DY, nodata, tran, proj, GridSpacingX, ScaleChipSizeY, swath_offset_bias_ref)

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -145,6 +145,9 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
 
     obj = autoRIFT_ISCE()
+
+    obj.WallisFilterWidth = preprocessing_filter_width
+
     obj.configure()
 
 #    ##########     uncomment if starting from preprocessed images

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -523,9 +523,10 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
         # FIXME: Filter width is a magic variable here and not exposed well.
         preprocessing_filter_width = 5
-        for ii, name in enumerate((m_name, s_name)):
-            if len(re.findall("S1[AB]_", name)) > 0:
-                preprocessing_filter_width = 21
+        if nc_sensor == 'S1':
+            preprocessing_filter_width = 21
+
+        print(f'Preprocessing filter width {preprocessing_filter_width}')
 
         preprocessing_methods = ['hps', 'hps']
         for ii, name in enumerate((m_name, s_name)):
@@ -538,10 +539,11 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
         print(f'Using preprocessing methods {preprocessing_methods}')
 
-        Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = runAutorift(
-            data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
-            noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info, preprocessing_methods=preprocessing_methods,
-            preprocessing_filter_width=preprocessing_filter_width,
+        Dx, Dy, InterpMask, ChipSizeX, GridSpacingX, ScaleChipSizeY, SearchLimitX, SearchLimitY, origSize, noDataMask = \
+            runAutorift(
+                data_m, data_s, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CSMAXx0, CSMAXy0,
+                noDataMask, optical_flag, nodata, mpflag, geogrid_run_info=geogrid_run_info,
+                preprocessing_methods=preprocessing_methods, preprocessing_filter_width=preprocessing_filter_width,
         )
         if nc_sensor is not None:
             import netcdf_output as no
@@ -628,7 +630,7 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
 
 
         if offset2vx is not None:
-        
+
             ds = gdal.Open(scale_factor)
             band = ds.GetRasterBand(1)
             scale_factor_1 = band.ReadAsArray()

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -289,6 +289,8 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
         obj.preprocess_filt_wal_nodata_fill()
     elif 'wallis' in preprocessing_methods:
         obj.preprocess_filt_wal()
+    elif 'fft' in preprocessing_methods:
+        obj.preprocess_filt_fft()
     else:
         obj.preprocess_filt_hps()
 #    obj.I1 = np.abs(I1)
@@ -514,6 +516,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                 acquisition = datetime.strptime(name.split('_')[3], '%Y%m%d')
                 if acquisition >= datetime(2003, 5, 31):
                     preprocessing_methods[ii] = 'wallis_fill'
+            elif len(re.findall("L[TM]0[45]_", name)) > 0:
+                preprocessing_methods[ii] = 'fft'
 
         print(f'Using preprocessing methods {preprocessing_methods}')
 

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -145,10 +145,9 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
 
 
     obj = autoRIFT_ISCE()
+    obj.configure()
 
     obj.WallisFilterWidth = preprocessing_filter_width
-
-    obj.configure()
 
 #    ##########     uncomment if starting from preprocessed images
 #    I1 = I1.astype(np.uint8)


### PR DESCRIPTION
With https://github.com/nasa-jpl/autoRIFT/pull/59 we changed the default Wallis filter width to 5. This change should only be applied to optical missions, so this PR sets the filter width back to 21 for Sentinel-1 pairs.

@forrestfwilliams want to look it over?