### PR TITLE
L7 bugfixes

### DIFF
--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -88,6 +88,7 @@ def _wallis_filter_fill(image, filter_width, std_cutoff):
     low_std = cv2.distanceTransform((~low_std).astype(np.uint8), distanceType=cv2.DIST_L2, maskSize=cv2.DIST_MASK_PRECISE) <= buff
     missing_data = (missing_data | low_std) & valid_domain
 
+    std[missing_data] = np.nan
     image = shifted / std
 
     valid_data = valid_domain & ~missing_data

--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -48,8 +48,9 @@ def _preprocess_filt_std(image, kernel):
     conv_squared_sum = cv2.filter2D(image**2, -1, kernel, borderType=cv2.BORDER_REFLECT)
 
     variance = conv_squared_sum - (conv_sum**2)
-    std = np.sqrt(variance) * np.sqrt(n / (n - 1))
+    variance = np.clip(variance, 0., None)
 
+    std = np.sqrt(variance) * np.sqrt(n / (n - 1))
     return std
 
 

--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -243,7 +243,7 @@ class autoRIFT:
         self.I1 = image_1
         self.I2 = image_2
 
-        self.zeroMask = zero_mask_1 & zero_mask_2
+        self.zeroMask = zero_mask_1 | zero_mask_2
 
     def preprocess_filt_wal(self):
         """


### PR DESCRIPTION
* When `wallis_fill` filtering images, the variance can end up less than zero (but very close to zero), leading to NaNs in the valid data, which blows up downstream and result in zero valid pixels
* fix the boolean operator used when combining image zero masks when `wallis_fill` filtering images