### PR TITLE
Update numpy bool call

### DIFF
--- a/testGeogridOptical.py
+++ b/testGeogridOptical.py
@@ -159,8 +159,8 @@ def runGeogrid(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, csminy, c
     obj.YSize = info.YSize
     from datetime import date
     import numpy as np
-    d0 = date(np.int(info.time[0:4]),np.int(info.time[4:6]),np.int(info.time[6:8]))
-    d1 = date(np.int(info1.time[0:4]),np.int(info1.time[4:6]),np.int(info1.time[6:8]))
+    d0 = date(int(info.time[0:4]),int(info.time[4:6]),int(info.time[6:8]))
+    d1 = date(int(info1.time[0:4]),int(info1.time[4:6]),int(info1.time[6:8]))
     date_dt_base = d1 - d0
     obj.repeatTime = date_dt_base.total_seconds()
 #    obj.repeatTime = (info1.time - info.time) * 24.0 * 3600.0

--- a/testGeogrid_ISCE.py
+++ b/testGeogrid_ISCE.py
@@ -374,8 +374,8 @@ def runGeogridOptical(info, info1, dem, dhdx, dhdy, vx, vy, srx, sry, csminx, cs
     obj.YSize = info.YSize
     from datetime import date
     import numpy as np
-    d0 = date(np.int(info.time[0:4]),np.int(info.time[4:6]),np.int(info.time[6:8]))
-    d1 = date(np.int(info1.time[0:4]),np.int(info1.time[4:6]),np.int(info1.time[6:8]))
+    d0 = date(int(info.time[0:4]),int(info.time[4:6]),int(info.time[6:8]))
+    d1 = date(int(info1.time[0:4]),int(info1.time[4:6]),int(info1.time[6:8]))
     date_dt_base = d1 - d0
     obj.repeatTime = date_dt_base.total_seconds()
 #    obj.repeatTime = (info1.time - info.time) * 24.0 * 3600.0

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -395,7 +395,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     import cv2
     kernel = np.ones((3,3),np.uint8)
     noDataMask = cv2.dilate(noDataMask.astype(np.uint8),kernel,iterations = 1)
-    noDataMask = noDataMask.astype(np.bool)
+    noDataMask = noDataMask.astype(np.bool_)
 
 
     return obj.Dx, obj.Dy, obj.InterpMask, obj.ChipSizeX, obj.GridSpacingX, obj.ScaleChipSizeY, obj.SearchLimitX, obj.SearchLimitY, obj.origSize, noDataMask

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -967,8 +967,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
-                    d0 = datetime(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
-                    d1 = datetime(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
+                    d0 = datetime(int(master_split[3][0:4]),int(master_split[3][4:6]),int(master_split[3][6:8]))
+                    d1 = datetime(int(slave_split[3][0:4]),int(slave_split[3][4:6]),int(slave_split[3][6:8]))
                     date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
                     date_dt = np.float64(date_dt_base)
                     if date_dt < 0:
@@ -1075,8 +1075,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
-                    d0 = datetime(np.int(master_split[2][0:4]),np.int(master_split[2][4:6]),np.int(master_split[2][6:8]))
-                    d1 = datetime(np.int(slave_split[2][0:4]),np.int(slave_split[2][4:6]),np.int(slave_split[2][6:8]))
+                    d0 = datetime(int(master_split[2][0:4]),int(master_split[2][4:6]),int(master_split[2][6:8]))
+                    d1 = datetime(int(slave_split[2][0:4]),int(slave_split[2][4:6]),int(slave_split[2][6:8]))
                     date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
                     date_dt = np.float64(date_dt_base)
                     if date_dt < 0:

--- a/testautoRIFT.py
+++ b/testautoRIFT.py
@@ -395,7 +395,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     import cv2
     kernel = np.ones((3,3),np.uint8)
     noDataMask = cv2.dilate(noDataMask.astype(np.uint8),kernel,iterations = 1)
-    noDataMask = noDataMask.astype(np.bool_)
+    noDataMask = noDataMask.astype(bool)
 
 
     return obj.Dx, obj.Dy, obj.InterpMask, obj.ChipSizeX, obj.GridSpacingX, obj.ScaleChipSizeY, obj.SearchLimitX, obj.SearchLimitY, obj.origSize, noDataMask

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -393,7 +393,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     import cv2
     kernel = np.ones((3,3),np.uint8)
     noDataMask = cv2.dilate(noDataMask.astype(np.uint8),kernel,iterations = 1)
-    noDataMask = noDataMask.astype(np.bool)
+    noDataMask = noDataMask.astype(np.bool_)
 
 
     return obj.Dx, obj.Dy, obj.InterpMask, obj.ChipSizeX, obj.GridSpacingX, obj.ScaleChipSizeY, obj.SearchLimitX, obj.SearchLimitY, obj.origSize, noDataMask

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -965,8 +965,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
-                    d0 = datetime(np.int(master_split[3][0:4]),np.int(master_split[3][4:6]),np.int(master_split[3][6:8]))
-                    d1 = datetime(np.int(slave_split[3][0:4]),np.int(slave_split[3][4:6]),np.int(slave_split[3][6:8]))
+                    d0 = datetime(int(master_split[3][0:4]),int(master_split[3][4:6]),int(master_split[3][6:8]))
+                    d1 = datetime(int(slave_split[3][0:4]),int(slave_split[3][4:6]),int(slave_split[3][6:8]))
                     date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
                     date_dt = np.float64(date_dt_base)
                     if date_dt < 0:
@@ -1073,8 +1073,8 @@ def generateAutoriftProduct(indir_m, indir_s, grid_location, init_offset, search
                         out_nc_filename = f"{ncname}_G{gridspacingx:04.0f}V02_P{np.floor(PPP):03.0f}.nc"
                     CHIPSIZEY = np.round(CHIPSIZEX * ScaleChipSizeY / 2) * 2
 
-                    d0 = datetime(np.int(master_split[2][0:4]),np.int(master_split[2][4:6]),np.int(master_split[2][6:8]))
-                    d1 = datetime(np.int(slave_split[2][0:4]),np.int(slave_split[2][4:6]),np.int(slave_split[2][6:8]))
+                    d0 = datetime(int(master_split[2][0:4]),int(master_split[2][4:6]),int(master_split[2][6:8]))
+                    d1 = datetime(int(slave_split[2][0:4]),int(slave_split[2][4:6]),int(slave_split[2][6:8]))
                     date_dt_base = (d1 - d0).total_seconds() / timedelta(days=1).total_seconds()
                     date_dt = np.float64(date_dt_base)
                     if date_dt < 0:

--- a/testautoRIFT_ISCE.py
+++ b/testautoRIFT_ISCE.py
@@ -393,7 +393,7 @@ def runAutorift(I1, I2, xGrid, yGrid, Dx0, Dy0, SRx0, SRy0, CSMINx0, CSMINy0, CS
     import cv2
     kernel = np.ones((3,3),np.uint8)
     noDataMask = cv2.dilate(noDataMask.astype(np.uint8),kernel,iterations = 1)
-    noDataMask = noDataMask.astype(np.bool_)
+    noDataMask = noDataMask.astype(bool)
 
 
     return obj.Dx, obj.Dy, obj.InterpMask, obj.ChipSizeX, obj.GridSpacingX, obj.ScaleChipSizeY, obj.SearchLimitX, obj.SearchLimitY, obj.origSize, noDataMask


### PR DESCRIPTION
Some numpy calls were deprecated for the `testautoRIFT*` scripts and raised the following error:
```
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'bool_'?
```

I've patched this here.