### PR TITLE
Remove unused Flag in autoRIFT.py

### DIFF
--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -464,8 +464,6 @@ class autoRIFT:
         Dy = np.empty(self.xGrid.shape, dtype=np.float32)
         Dy.fill(np.nan)
 
-        Flag = 3
-
         if self.ChipSize0X > self.GridSpacingX:
             if np.mod(self.ChipSize0X, self.GridSpacingX) != 0:
                 sys.exit(
@@ -551,12 +549,6 @@ class autoRIFT:
             SearchLimitY0[idxZero] = 0
             SearchLimitX0[(np.logical_not(idxZero)) & (SearchLimitX0 < self.minSearch)] = self.minSearch
             SearchLimitY0[(np.logical_not(idxZero)) & (SearchLimitY0 < self.minSearch)] = self.minSearch
-
-            if ((xGrid0.shape[0] - 2) / (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio) < 5) | (
-                (xGrid0.shape[1] - 2) / (self.sparseSearchSampleRate * ChipSize0_GridSpacing_oversample_ratio) < 5
-            ):
-                Flag = 2
-                return Flag
 
             # Setup for coarse search: sparse sampling / resize
             rIdxC = slice(
@@ -792,12 +784,10 @@ class autoRIFT:
                 Dx[idxRaw | idxFill] = DxF[idxRaw | idxFill]
                 Dy[idxRaw | idxFill] = DyF[idxRaw | idxFill]
 
-        Flag = 1
         ChipSizeY = np.round(ChipSizeX * self.ScaleChipSizeY / 2) * 2
         self.Dx = Dx
         self.Dy = Dy
         self.InterpMask = InterpMask
-        self.Flag = Flag
         self.ChipSizeX = ChipSizeX
         self.ChipSizeY = ChipSizeY
 
@@ -857,7 +847,6 @@ class autoRIFT:
         self.Dx = None
         self.Dy = None
         self.InterpMask = None
-        self.Flag = None
         self.ChipSizeX = None
         self.ChipSizeY = None
 


### PR DESCRIPTION
The `Flag` variable here appears to be entirely unused. 

Early on in `autoRIFT.py,` it's set to `Flag = 3`, but isn't used until it's either:
1. set to `Flag = 1`, or
2.  set to `Flag = 2` after an `if` statement and returned in an early return, but the value isn't captured when returned

`Flag` is then used to set the `autoRIFT` class instance `self.Flag = Flag` (Note: this is always `self.Flag = 1` at this point in the code). However, `self.Flag` also appears to be unused, and removing it entirely from the `autoRIFT` class has no effect, so I've removed it here as well.

The quality check that causes the early return and autoRIFT to fail to process here:
https://github.com/nasa-jpl/autoRIFT/compare/master...jhkennedy:autoRIFT:remove-unused-flag?expand=1#diff-aef32708be8cb7db896244136a3694fcc729dc6cd5f03753863b2387c579dae1L555-L557

prevents Sentinel-1 burst base processing and, once removed, allows bursts to process just fine, indicating it's a check that is probably not needed. IF that check is needed, either:
*  a descriptive error should be raised or 
* some action should be taken based on that case

neither of which happens currently. 
