### PR TITLE
Stop using legacy numpy RandomState Random Number Generator

### DIFF
--- a/geo_autoRIFT/autoRIFT/autoRIFT.py
+++ b/geo_autoRIFT/autoRIFT/autoRIFT.py
@@ -97,7 +97,8 @@ def _wallis_filter_fill(image, filter_width, std_cutoff):
     # wallis filter normalizes the imagery to have a mean=0 and std=1;
     # fill with random values from a normal distribution with same mean and std
     fill_data = valid_domain & missing_data
-    random_fill = np.random.normal(size=(fill_data.sum(),))
+    rng = np.random.default_rng()
+    random_fill = rng.normal(size=(fill_data.sum(),))
     image[fill_data] = random_fill
 
     return image, zero_mask

--- a/netcdf_output.py
+++ b/netcdf_output.py
@@ -26,8 +26,9 @@ def get_satellite_attribute(info):
 
 
 def v_error_cal(vx_error, vy_error):
-    vx = np.random.normal(0, vx_error, 1000000)
-    vy = np.random.normal(0, vy_error, 1000000)
+    rng = np.random.default_rng()
+    vx = rng.normal(0, vx_error, 1000000)
+    vy = rng.normal(0, vy_error, 1000000)
     v = np.sqrt(vx**2 + vy**2)
     return np.std(v)
 


### PR DESCRIPTION
Numpy recommends *not* using the distribution members exposed directly on the `np.random` module as they alias to methods on a global singleton `RandomState` instance and to instead use a `Generator` instance which is both faster and has better statistical properties. 

See: 
* https://docs.astral.sh/ruff/rules/numpy-legacy-random/
* https://numpy.org/neps/nep-0019-rng-policy.html
* Generator: https://numpy.org/doc/stable/reference/random/generated/numpy.random.Generator.normal.html#numpy.random.Generator.normal
* RandomSate: https://numpy.org/doc/stable/reference/random/generated/numpy.random.RandomState.normal.html#numpy.random.RandomState.normal